### PR TITLE
Add a `lexer` option for the Parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -21,11 +21,11 @@ var extname = path.extname;
 var Parser = exports = module.exports = function Parser(str, filename, options){
   //Strip any UTF-8 BOM off of the start of `str`, if it exists.
   this.input = str.replace(/^\uFEFF/, '');
-  this.lexer = new Lexer(this.input, filename);
   this.filename = filename;
   this.blocks = {};
   this.mixins = {};
-  this.options = options;
+  this.options = options || {};
+  this.lexer = new (this.options.lexer || Lexer)(this.input, filename);
   this.contexts = [this];
   this.inMixin = false;
 };
@@ -735,7 +735,7 @@ Parser.prototype = {
       tag.textOnly = true;
       this.advance();
     }
-    
+
     if (tag.selfClosing
         && ['newline', 'outdent', 'eos'].indexOf(this.peek().type) === -1
         && (this.peek().type !== 'text' || /^\s*$/.text(this.peek().val))) {


### PR DESCRIPTION
Hello,

I'm currently building a jade package for the meteor framework. I need to do some modifications of the `Lexer` object and then ask the parser to use my custom object. Is that already possible? If no is that something that could be added?

Thank you