### PR TITLE
Adds a new `context` keyword.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -607,6 +607,17 @@ Compiler.prototype = {
   },
 
   /**
+   * Visit `context`
+   *
+   * @param {Context} context
+   * @api public
+   */
+
+  visitContext: function(context){
+    this.buf.push(context.val);
+  },
+
+  /**
    * Compile attributes.
    */
 

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -796,6 +796,14 @@ Lexer.prototype = {
     return this.scan(/^: */, ':');
   },
 
+  /**
+   * Context (insert js directly into current template context)
+   */
+
+  context: function() {
+    return this.scan(/^context +([^:\n]+)/, 'context');
+  },
+
   fail: function () {
     if (/^ ($|\n)/.test(this.input)) {
       this.consume(1);
@@ -842,6 +850,7 @@ Lexer.prototype = {
       || this.mixinBlock()
       || this.include()
       || this.includeFiltered()
+      || this.context()
       || this.mixin()
       || this.call()
       || this.conditional()

--- a/lib/nodes/context.js
+++ b/lib/nodes/context.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var Node = require('./node');
+
+/**
+ * Initialize a `Context` node with the given code `val`.
+ *
+ * @param {String} val
+ * @api public
+ */
+
+var Context = module.exports = function Context(val, filename) {
+  this.val = val;
+  this.filename = filename;
+};
+
+/**
+ * Inherit from `Node`.
+ */
+
+Context.prototype = new Node;
+Context.prototype.constructor = Context;
+
+Context.prototype.type = 'Context';

--- a/lib/nodes/context.js
+++ b/lib/nodes/context.js
@@ -18,7 +18,7 @@ var Context = module.exports = function Context(val, filename) {
  * Inherit from `Node`.
  */
 
-Context.prototype = new Node;
+Context.prototype = Object.create(Node.prototype);
 Context.prototype.constructor = Context;
 
 Context.prototype.type = 'Context';

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -14,3 +14,4 @@ exports.Comment = require('./comment');
 exports.Literal = require('./literal');
 exports.BlockComment = require('./block-comment');
 exports.Doctype = require('./doctype');
+exports.Context = require('./context');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -229,6 +229,8 @@ Parser.prototype = {
         return this.parseCall();
       case 'interpolation':
         return this.parseInterpolation();
+      case 'context':
+        return this.parseContext();
       case 'yield':
         this.advance();
         var block = new nodes.Block;
@@ -786,5 +788,26 @@ Parser.prototype = {
     }
 
     return tag;
+  },
+
+  /**
+   * Parse context (insert a js file into the current jade context).
+   */
+
+  parseContext: function(tag){
+    var fs = require('fs');
+    var p = require('path');
+    var tok = this.expect('context');
+    var path = tok.val.trim();
+
+    // Force extension to js if there isn't any
+    if (!~p.basename(path).indexOf('.')) {
+      path += '.js';
+    }
+
+    path = this.resolvePath(path, 'context');
+
+    var str = fs.readFileSync(path, 'utf8').replace(/\r/g, '');
+    return new nodes.Context(str, path);
   }
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -737,7 +737,7 @@ Parser.prototype = {
       tag.textOnly = true;
       this.advance();
     }
-    
+
     if (tag.selfClosing
         && ['newline', 'outdent', 'eos'].indexOf(this.peek().type) === -1
         && (this.peek().type !== 'text' || /^\s*$/.text(this.peek().val))) {
@@ -799,11 +799,6 @@ Parser.prototype = {
     var p = require('path');
     var tok = this.expect('context');
     var path = tok.val.trim();
-
-    // Force extension to js if there isn't any
-    if (!~p.basename(path).indexOf('.')) {
-      path += '.js';
-    }
 
     path = this.resolvePath(path, 'context');
 

--- a/test/cases/auxiliary/somefunc.js
+++ b/test/cases/auxiliary/somefunc.js
@@ -1,0 +1,3 @@
+function foobar() {
+  return 'Foobar from somefunc.js';
+}

--- a/test/cases/context-with-func.html
+++ b/test/cases/context-with-func.html
@@ -1,0 +1,1 @@
+<div class="foobar">Foobar from somefunc.js</div>

--- a/test/cases/context-with-func.jade
+++ b/test/cases/context-with-func.jade
@@ -1,0 +1,3 @@
+context auxiliary/somefunc
+
+.foobar #{foobar()}

--- a/test/cases/context-with-func.jade
+++ b/test/cases/context-with-func.jade
@@ -1,3 +1,3 @@
-context auxiliary/somefunc
+context auxiliary/somefunc.js
 
 .foobar #{foobar()}

--- a/test/cases/context.html
+++ b/test/cases/context.html
@@ -1,0 +1,1 @@
+<p>The STRING_SUBSTITUTIONS object has 5 keys</p>

--- a/test/cases/context.jade
+++ b/test/cases/context.jade
@@ -1,0 +1,4 @@
+context auxiliary/includable.js
+
+p
+  | The STRING_SUBSTITUTIONS object has #{Object.keys(STRING_SUBSTITUTIONS).length} keys


### PR DESCRIPTION
It is similar to `include`, but instead of including the passed file's contents into the buffered output, the file's content is inserted directly into the compiled template code. This allows you to insert arbitrary javascript into the context of the template, such as JSON data, a bunch of helper javascript functions, etc.

This is particularly useful for things like static site generators that do not have some server middleware to pass in `locals` to the jade template.