### PR TITLE
Move inline expression parsing from the compiler to the parser

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -92,31 +92,10 @@ Compiler.prototype = {
    * Buffer the given `str` exactly as is or with interpolation
    *
    * @param {String} str
-   * @param {Boolean} interpolate
    * @api public
    */
 
-  buffer: function (str, interpolate) {
-    var self = this;
-    if (interpolate) {
-      var match = /(\\)?([#!]){((?:.|\n)*)$/.exec(str);
-      if (match) {
-        this.buffer(str.substr(0, match.index), false);
-        if (match[1]) { // escape
-          this.buffer(match[2] + '{', false);
-          this.buffer(match[3], true);
-          return;
-        } else {
-          var rest = match[3];
-          var range = parseJSExpression(rest);
-          var code = ('!' == match[2] ? '' : 'jade.escape') + "((jade_interp = " + range.src + ") == null ? '' : jade_interp)";
-          this.bufferExpression(code);
-          this.buffer(rest.substr(range.end + 1), true);
-          return;
-        }
-      }
-    }
-
+  buffer: function (str) {
     str = JSON.stringify(str);
     str = str.substr(1, str.length - 2);
 
@@ -143,7 +122,7 @@ Compiler.prototype = {
 
   bufferExpression: function (src) {
     if (isConstant(src)) {
-      return this.buffer(toConstant(src) + '', false)
+      return this.buffer(toConstant(src) + '')
     }
     if (this.lastBufferedIdx == this.buf.length) {
       if (this.lastBufferedType === 'text') this.lastBuffered += '"';
@@ -476,7 +455,7 @@ Compiler.prototype = {
       function(node){ return node.val; }
     ).join('\n');
     filter.attrs.filename = this.options.filename;
-    this.buffer(filters(filter.name, text, filter.attrs), true);
+    this.buffer(filters(filter.name, text, filter.attrs));
   },
 
   /**
@@ -487,7 +466,7 @@ Compiler.prototype = {
    */
 
   visitText: function(text){
-    this.buffer(text.val, true);
+    this.buffer(text.val);
   },
 
   /**

--- a/lib/nodes/code.js
+++ b/lib/nodes/code.js
@@ -9,18 +9,24 @@ var Node = require('./node');
  * @param {String} val
  * @param {Boolean} buffer
  * @param {Boolean} escape
+ * @param {Boolean} inline
  * @api public
  */
 
-var Code = module.exports = function Code(val, buffer, escape) {
+var Code = module.exports = function Code(val, buffer, escape, inline) {
   this.val = val;
   this.buffer = buffer;
   this.escape = escape;
+  this.inline = !!inline;
   if (val.match(/^ *else/)) this.debug = false;
 };
 
 // Inherit from `Node`.
 Code.prototype = Object.create(Node.prototype);
 Code.prototype.constructor = Code;
+
+Code.prototype.isInline = function(){
+  return this.inline;
+};
 
 Code.prototype.type = 'Code'; // prevent the minifiers removing this

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -640,11 +640,11 @@ Parser.prototype = {
         if (opener === "#[")
           buffer.push(new Parser(range.src, this.filename, this.options).parse());
         else
-          buffer.push(new nodes.Code(range.src, true, opener === "#{"));
+          buffer.push(new nodes.Code(range.src, true, opener === "#{", true));
 
         range.end += 1; // for the closing ] or }
         if (rest.length > range.end) {
-          var nextBuffer = this.parseTextWithInlineTags(rest.substr(range.end + 1));
+          var nextBuffer = this.parseTextWithInlineTags(rest.substr(range.end));
           Array.prototype.push.apply(buffer, nextBuffer);
         }
       }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -609,34 +609,54 @@ Parser.prototype = {
   },
 
   parseTextWithInlineTags: function (str) {
+    var buffer = [];
     var line = this.line();
+    var match;
 
-    var match = /(\\)?#\[((?:.|\n)*)$/.exec(str);
-    if (match) {
-      if (match[1]) { // escape
-        var text = new nodes.Text(str.substr(0, match.index) + '#[');
+    // inline tag or expression
+    if (match = /(\\)?(#{|!{|#\[)((?:.|\n)*)$/.exec(str)) {
+      var escape = match[1];
+      var opener = match[2];
+      var rest   = match[3];
+
+      if (escape) {
+        var text = new nodes.Text(str.substr(0, match.index) + opener);
         text.line = line;
-        var rest = this.parseTextWithInlineTags(match[2]);
+        rest = this.parseTextWithInlineTags(rest);
         if (rest[0].type === 'Text') {
           text.val += rest[0].val;
           rest.shift();
         }
-        return [text].concat(rest);
+        buffer.push(text);
+        buffer = buffer.concat(rest);
+
       } else {
-        var text = new nodes.Text(str.substr(0, match.index));
-        text.line = line;
-        var buffer = [text];
-        var rest = match[2];
+        if (match.index !== 0) {
+          var text = new nodes.Text(str.substr(0, match.index));
+          text.line = line;
+          buffer.push(text);
+        }
         var range = parseJSExpression(rest);
-        var inner = new Parser(range.src, this.filename, this.options);
-        buffer.push(inner.parse());
-        return buffer.concat(this.parseTextWithInlineTags(rest.substr(range.end + 1)));
+        if (opener === "#[")
+          buffer.push(new Parser(range.src, this.filename, this.options).parse());
+        else
+          buffer.push(new nodes.Code(range.src, true, opener === "#{"));
+
+        range.end += 1; // for the closing ] or }
+        if (rest.length > range.end) {
+          var nextBuffer = this.parseTextWithInlineTags(rest.substr(range.end + 1));
+          Array.prototype.push.apply(buffer, nextBuffer);
+        }
       }
+
+    // simple text
     } else {
       var text = new nodes.Text(str);
       text.line = line;
-      return [text];
+      buffer.push(text);
     }
+
+    return buffer;
   },
 
   /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -608,10 +608,31 @@ Parser.prototype = {
     }
   },
 
+
+  /**
+   * Take a "<a>xxx <a>yyy</a> <b>zzz</b></a>" string and returns
+   * "#[a xxx #[a yyy] #[b zzz]]" so that the `parseTextWithInlineTags` function
+   * will parse inline HTML tags.
+   *
+   * @param  {String} str
+   * @return {String}
+   * @api private
+   */
+  normalizeInlineTags: function(str) {
+    var inlineTagRegex = /<(\w[-:\w]*)>(.+)<\/\1>/g;
+    var normalizedStr = str.replace(inlineTagRegex, "#[$1 $2]");
+    if (str === normalizedStr)
+      return str;
+    else
+      return this.normalizeInlineTags(normalizedStr);
+  },
+
   parseTextWithInlineTags: function (str) {
     var buffer = [];
     var line = this.line();
     var match;
+
+    str = this.normalizeInlineTags(str);
 
     // inline tag or expression
     if (match = /(\\)?(#{|!{|#\[)((?:.|\n)*)$/.exec(str)) {


### PR DESCRIPTION
See #1460.

Actually inline tags are parsed by the parser - as expected.
So the issue only concern inline code with the `#{}` syntax.