### PR TITLE
Use node-resolve to resolve paths if normal resolving fails

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -128,6 +128,13 @@ Parser.prototype = {
       this.context(parser);
       var ast = parser.parse();
       this.context();
+      
+      //append main
+      for(var i = 0; i < block.nodes.length; i++){
+          if(block.nodes[i].type == "Tag" && block.nodes[i].name == "main"){
+              ast.push(block.nodes[i]);
+          }
+      }
 
       // hoist mixins
       for (var name in this.mixins)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -450,11 +450,16 @@ Parser.prototype = {
     if (path[0] === '/' && !this.options.basedir)
       throw new Error('the "basedir" option is required to use "' + purpose + '" with "absolute" paths');
 
-    path = join(path[0] === '/' ? this.options.basedir : dirname(this.filename), path);
 
     if (basename(path).indexOf('.') === -1) path += '.jade';
+    var p = join(path[0] === '/' ? this.options.basedir : dirname(this.filename), path);
 
-    return path;
+    if(!require("fs").existsSync(path)){
+      try{
+        p = require("resolve").sync(path,{basedir:dirname(this.filename)});
+      }catch(e){}
+    }
+    return p;
   },
 
   /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -129,6 +129,8 @@ Parser.prototype = {
       var ast = parser.parse();
       this.context();
       
+      ast.extends = parser.filename;
+      
       //append main
       for(var i = 0; i < block.nodes.length; i++){
           if(block.nodes[i].type == "Tag" && block.nodes[i].name == "main"){

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "character-parser": "1.2.0",
     "monocle": "1.1.51",
     "with": "~3.0.0",
-    "constantinople": "~2.0.0"
+    "constantinople": "~2.0.0",
+    "resolve": "^0.6.2"
   },
   "devDependencies": {
     "coffee-script": "*",


### PR DESCRIPTION
I've extended the resolvePath function so, that it uses node-resolve as fallback if it cannot resolve the file.
This is especially useful if you want to include/extend from a view in a submodule.

I need this for one of my projects and of course it'd be cool to include this into the main repository.

What do you think?