### PR TITLE
export to correct directory even if sub-directories

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -7,7 +7,6 @@
 var fs = require('fs')
   , program = require('commander')
   , path = require('path')
-  , basename = path.basename
   , dirname = path.dirname
   , resolve = path.resolve
   , exists = fs.existsSync || path.existsSync
@@ -154,7 +153,7 @@ function renderFile(path) {
         var fn = options.client ? jade.compileClient(str, options) : jade.compile(str, options);
         var extname = options.client ? '.js' : '.html';
         path = path.replace(re, extname);
-        if (program.out) path = join(program.out, basename(path));
+        if (program.out) path = join(program.out, path);
         var dir = resolve(dirname(path));
         mkdirp(dir, 0755, function(err){
           if (err) throw err;


### PR DESCRIPTION
Without this change, if you use an `out` directory and your templates are in sub-directories, the directory structure gets squished. Think you had controllers and views per controller, then that hierarchy gets flattened.

This patch fixes that issue.