### PR TITLE
mixin precompilation

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -40,7 +40,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.parentIndents = 0;
   this.terse = false;
   this.mixins = {};
-  this.dynamicMixins = false;
+  this.dynamicMixins = options.keepMixins ? true : false;
   if (options.doctype) this.setDoctype(options.doctype);
 };
 
@@ -338,6 +338,7 @@ Compiler.prototype = {
   visitMixin: function(mixin){
     var name = 'jade_mixins[';
     var args = mixin.args || '';
+    args = 'jade, buf' + (args?', ':'') + args;
     var block = mixin.block;
     var attrs = mixin.attrs;
     var attrsBlocks = mixin.attributeBlocks;

--- a/lib/jade.js
+++ b/lib/jade.js
@@ -124,7 +124,7 @@ function parse(str, options){
 
   var body = ''
     + 'var buf = [];\n'
-    + 'var jade_mixins = {};\n'
+    + 'var jade_mixins = locals && locals.jade_mixins || {};\n'
     + 'var jade_interp;\n'
     + (options.self
       ? 'var self = locals || {};\n' + js


### PR DESCRIPTION
Hello,

This PR is hopefully an acceptable way to separate the compilation of the mixins from the compilation of the templates.

In other words, you can compile mixins once (as a bundle or one by one) and then the compilation of a template will not need to recompile all the mixins :-)

I have used it for some time now and did not run into issues. All tests are passing.

I think this might be a nice addition for the dynamic capabilities of jade 
 - combined with the dynamic mixin calls
 - to allow for easier componentization of mixins (as npm modules for instance)

Tell me what you think.

Example code:

mixin.jade
````
mixin dynamic(world)
 | hello #{world}
````

 template.jade
````
+dynamic("world")
````

index.js
````
var jade = require('jade');
var locals = {
  keepMixins: true,
  jade_mixins: {}
};

var mixin = jade.renderFile('mixin.jade', locals);
var html = jade.renderFile('template.jade', locals);
console.log(html);
````

=> result
````
hello world
````
