### PR TITLE
Allow included template to access blocks declared from extends

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -576,7 +576,11 @@ Parser.prototype = {
     var parser = new this.constructor(str, path, this.options);
     parser.dependencies = this.dependencies;
 
-    parser.blocks = utils.merge({}, this.blocks);
+    if (!this.extending)
+      parser.blocks = utils.merge({}, this.blocks);
+    else
+      parser.blocks = utils.merge(this.extending.blocks, this.blocks);
+
     parser.included = true;
 
     parser.mixins = this.mixins;


### PR DESCRIPTION
This patch doesn't appear to break any tests and works for me, but I'm not sure if it creates unintended behavior so it needs some feedback. If it looks nice to you guys I'll write some tests for it.

# Motivation

Included templates can append to blocks declared in the includer, but cannot append to blocks available to the includer from what it extends. Example:

/views/**layout**.jade:
```jade
block content

block additionalStuff
```

/views/**blog**.jade:
```jade
extends layout
include mixins/comments

block content
    p Blog post.
    +comments()
```

/views/**mixins/comments**.jade:
```jade
mixin comments()
    p Comments.

block append additionalStuff
    p hello!
```

----------------

This doesn't work unless you change blog.jade to:

```jade
extends layout
block append additionalStuff
include mixins/comments

block content
    p Blog post.
    +comments()
```

Which is weird and annoying.