### PR TITLE
Space control

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -439,6 +439,7 @@ Compiler.prototype = {
     if (pp && !tag.isInline())
       this.prettyIndent(0, true);
 
+    this.buffer(tag.before);
     if (tag.selfClosing || (!this.xml && selfClosing.indexOf(tag.name) !== -1)) {
       this.buffer('<');
       bufferName();
@@ -471,6 +472,7 @@ Compiler.prototype = {
       bufferName();
       this.buffer('>');
     }
+    this.buffer(tag.after);
 
     if ('pre' == tag.name) this.escape = false;
 

--- a/lib/nodes/tag.js
+++ b/lib/nodes/tag.js
@@ -15,13 +15,15 @@ var inlineTags = require('../inline-tags');
 var Tag = module.exports = function Tag(name, block) {
   Attrs.call(this);
   this.before = this.after = '';
-  if (name[0] == '_') {
-    this.before = ' ';
-    name = name.slice(1);
-  }
-  if (name.slice(-1) == '_') {
-    this.after = ' ';
-    name = name.slice(0, -1);
+  if (name && name.length > 1) {
+    if (name[0] == '_') {
+      this.before = ' ';
+      name = name.slice(1);
+    }
+    if (name.slice(-1) == '_') {
+      this.after = ' ';
+      name = name.slice(0, -1);
+    }
   }
   this.name = name;
   this.block = block || new Block;

--- a/lib/nodes/tag.js
+++ b/lib/nodes/tag.js
@@ -14,6 +14,15 @@ var inlineTags = require('../inline-tags');
 
 var Tag = module.exports = function Tag(name, block) {
   Attrs.call(this);
+  this.before = this.after = '';
+  if (name[0] == '_') {
+    this.before = ' ';
+    name = name.slice(1);
+  }
+  if (name.slice(-1) == '_') {
+    this.after = ' ';
+    name = name.slice(0, -1);
+  }
   this.name = name;
   this.block = block || new Block;
 };


### PR DESCRIPTION
Hi,

This is a proposal to add space before and after the tag.

```jade
p
  span no space
p
  _span space before
p
  span_ space after
p
  _span_ space before and after
```

```html
<p><span>no space</span></p><p> <span>space before</span></p><p><span>space after</span> </p><p> <span>space before and after</span> </p>
```

```jade
p
  | This is a
  _a_(href="#") link
  | one
```

```html
<p>This is a <a href="#">link</a> one</p>
```

```jade
.btn-group
  button.btn Button 1
  _button.btn Give me some space
```

```html
<div class="btn-group"><button class="btn">Button 1</button> <button class="btn">Give me some space</button></div>
```