### PR TITLE
Disallow colon at start or end of attributes

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -668,6 +668,9 @@ Lexer.prototype = {
           if (val) assertExpression(val)
           key = key.trim();
           key = key.replace(/^['"]|['"]$/g, '');
+          if (key[0] === ':' || key[key.length - 1] === ':') {
+            throw new Error('":" is not valid as the start or end of an un-quoted attribute.');
+          }
           tok.attrs.push({
             name: key,
             val: '' == val ? true : val,

--- a/test/anti-cases/colon-attribute-2.jade
+++ b/test/anti-cases/colon-attribute-2.jade
@@ -1,0 +1,1 @@
+option(value="level1", class: selected)

--- a/test/anti-cases/colon-attribute-3.jade
+++ b/test/anti-cases/colon-attribute-3.jade
@@ -1,0 +1,1 @@
+option(value="level1", class :selected)

--- a/test/anti-cases/colon-attribute.jade
+++ b/test/anti-cases/colon-attribute.jade
@@ -1,0 +1,1 @@
+option(value="level1", class : selected)


### PR DESCRIPTION
[closes #1182]

This prevents things like:

```jade
option(value="level1", class: selected)
```

from compiling, but if you really wanted the old behavior, you just have to quote the attribute:

```jade
option(value="level1", "class:" selected)
```

```html
<option value="level1" class:="class:" selected="selected">Level One</option>
```

This is a breaking change, so part of the 2.0.0 track.