### PR TITLE
Improve testing coverage for the Jade CLI application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ testing
 node_modules
 lib-cov
 coverage
+cov-pt*
 npm-debug.log
 /test/output
 /test/temp

--- a/bin/jade.js
+++ b/bin/jade.js
@@ -126,6 +126,9 @@ if (files.length) {
         }
       });
     });
+    process.on('SIGINT', function() {
+      process.exit(1);
+    });
   } else {
     files.forEach(renderFile);
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "test": "mocha -R spec && npm run coverage",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha",
+    "coverage": "rimraf cov-pt* && istanbul cover --dir cov-pt0 node_modules/mocha/bin/_mocha && node support/cov-combine.js cov-pt*/coverage.json",
     "prepublish": "npm prune && linify transform bin && npm run build",
     "build": "npm run compile",
     "compile": "npm run compile-full && npm run compile-runtime",

--- a/support/cov-combine.js
+++ b/support/cov-combine.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/*
+ * Combines multiple istanbul coverage JSON result files to create one
+ * coverage HTML that covers all the individual results.
+ *
+ * E.g.
+ * $ cov-combine.js cov-pt[0-9]/coverage.json
+ * $ www-browser coverage/index.html
+ */
+
+/*
+ * Written by @TimothyGu. Adapted from
+ * https://github.com/gotwarlost/istanbul/blob/master/README.md#generate-reports-given-a-bunch-of-coverage-json-objects
+ */
+
+var istanbul  = require('istanbul')
+  , collector = new istanbul.Collector()
+  , reporter  = new istanbul.Reporter();
+
+for (var i = 2; i < process.argv.length; i++) {
+  collector.add(require(
+    process.argv[i].replace(/^([^\/])/, process.cwd() + '/$1')));
+  console.log('adding ' + process.argv[i]);
+}
+
+reporter.addAll([ 'lcov', 'text' ]);
+reporter.write(collector, false, function () {
+  console.log('All reports generated');
+});

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -23,7 +23,20 @@ try {
   }
 }
 
-describe('command line', function () {
+describe('command line with HTML output', function () {
+  it('jade --no-debug input.jade', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
+    fs.writeFileSync(__dirname + '/temp/input.html', '<p>output not written</p>');
+    run('--no-debug input.jade', function (err) {
+      if (err) return done(err);
+      var html = fs.readFileSync(__dirname + '/temp/input.html', 'utf8');
+      assert(html === '<div class="foo">bar</div>');
+      done();
+    });
+  });
+});
+
+describe('command line with client JS output', function () {
   it('jade --no-debug --client --name myTemplate input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
     fs.writeFileSync(__dirname + '/temp/input.js', 'throw new Error("output not written");');

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -34,6 +34,16 @@ describe('command line with HTML output', function () {
       done();
     });
   });
+  it('jade --no-debug --obj "{\'loc\':\'str\'}" input.jade', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo= loc');
+    fs.writeFileSync(__dirname + '/temp/input.html', '<p>output not written</p>');
+    run('--no-debug --obj "{\'loc\':\'str\'}" input.jade', function (err) {
+      if (err) return done(err);
+      var html = fs.readFileSync(__dirname + '/temp/input.html', 'utf8');
+      assert(html === '<div class="foo">str</div>');
+      done();
+    });
+  });
 });
 
 describe('command line with client JS output', function () {

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -66,6 +66,16 @@ describe('command line with HTML output', function () {
       done();
     });
   });
+  it('jade --no-debug -E special-html input.jade', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
+    fs.writeFileSync(__dirname + '/temp/input.special-html', '<p>output not written</p>');
+    run('--no-debug -E special-html input.jade', function (err) {
+      if (err) return done(err);
+      var html = fs.readFileSync(__dirname + '/temp/input.special-html', 'utf8');
+      assert(html === '<div class="foo">bar</div>');
+      done();
+    });
+  });
   it('jade --no-debug --obj "{\'loc\':\'str\'}" input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo= loc');
     fs.writeFileSync(__dirname + '/temp/input.html', '<p>output not written</p>');
@@ -99,6 +109,16 @@ describe('command line with client JS output', function () {
     run('--no-debug --client --name myTemplate input.jade', function (err) {
       if (err) return done(err);
       var template = Function('', fs.readFileSync(__dirname + '/temp/input.js', 'utf8') + ';return myTemplate;')();
+      assert(template() === '<div class="foo">bar</div>');
+      done();
+    });
+  });
+  it('jade --no-debug --client -E special-js --name myTemplate input.jade', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
+    fs.writeFileSync(__dirname + '/temp/input.special-js', 'throw new Error("output not written");');
+    run('--no-debug --client -E special-js --name myTemplate input.jade', function (err) {
+      if (err) return done(err);
+      var template = Function('', fs.readFileSync(__dirname + '/temp/input.special-js', 'utf8') + ';return myTemplate;')();
       assert(template() === '<div class="foo">bar</div>');
       done();
     });

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -44,6 +44,14 @@ describe('command line with HTML output', function () {
       done();
     });
   });
+  it('cat input.jade | jade --no-debug', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
+    run('--no-debug', 'cat input.jade | ', function (err, stdout, stderr) {
+      if (err) return done(err);
+      assert(stdout === '<div class="foo">bar</div>');
+      done();
+    });
+  });
 });
 
 describe('command line with client JS output', function () {
@@ -53,6 +61,16 @@ describe('command line with client JS output', function () {
     run('--no-debug --client --name myTemplate input.jade', function (err) {
       if (err) return done(err);
       var template = Function('', fs.readFileSync(__dirname + '/temp/input.js', 'utf8') + ';return myTemplate;')();
+      assert(template() === '<div class="foo">bar</div>');
+      done();
+    });
+  });
+  it('cat input.jade | jade --no-debug --client --name myTemplate', function (done) {
+    fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
+    fs.writeFileSync(__dirname + '/temp/input.js', 'throw new Error("output not written");');
+    run('--no-debug --client --name myTemplate', 'cat input.jade | ', function (err, stdout) {
+      if (err) return done(err);
+      var template = Function('', stdout + ';return myTemplate;')();
       assert(template() === '<div class="foo">bar</div>');
       done();
     });

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -5,8 +5,12 @@ var path = require('path');
 var assert = require('assert');
 var cp = require('child_process');
 
-function run(args, callback) {
-  cp.exec('node ' + JSON.stringify(path.resolve(__dirname + '/../bin/jade.js')) + ' ' + args, {
+function run(args, stdin, callback) {
+  if (arguments.length === 2) {
+    callback = stdin;
+    stdin    = null;
+  }
+  cp.exec((stdin || '') + 'node ' + JSON.stringify(path.resolve(__dirname + '/../bin/jade.js')) + ' ' + args, {
     cwd: __dirname + '/temp'
   }, callback);
 }

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -40,6 +40,16 @@ describe('command line', function () {
       return done();
     });
   });
+  it('jade --no-debug --client --name-after-file _InPuTwIthWEiRdNaMME.jade', function (done) {
+    fs.writeFileSync(__dirname + '/temp/_InPuTwIthWEiRdNaMME.jade', '.foo bar');
+    fs.writeFileSync(__dirname + '/temp/_InPuTwIthWEiRdNaMME.js', 'throw new Error("output not written");');
+    run('--no-debug --client --name-after-file _InPuTwIthWEiRdNaMME.jade', function (err, stdout, stderr) {
+      if (err) return done(err);
+      var template = Function('', fs.readFileSync(__dirname + '/temp/_InPuTwIthWEiRdNaMME.js', 'utf8') + ';return InputwithweirdnammeTemplate;')();
+      assert(template() === '<div class="foo">bar</div>');
+      return done();
+    });
+  });
 });
 
 describe('command line watch mode', function () {


### PR DESCRIPTION
This PR can be understood to have two parts:

1. improve test coverage
2. allow tracking test coverage of bin/jade.js

## Improving test coverage

For the first part, I have added tests for:

- `--obj` option of `bin/jade.js`
- reading from `stdin` and the `stdin()` function
- routines for prettifying the template name, i.e. the `replace()` call in `getNameFromFileName()`

## Test coverage report

For the second part I had to use some "hacks" and workarounds, because, unfortunately, istanbul is not as flexible as I would like it to be:

1. It does not support tracking JavaScript scripts spawned by `child_process.spawn()` or child_process.exec()`. Therefore, it is   necessary to execute separate istanbul instances for every command   spawned. This leads to the second problem:

2. Istanbul does not support "concatenating" or appending coverage data.   This means that, unlike gcov for C programs, when you run a new   `istanbul cover` it overwrites the earlier data.

   To work around this, I made istanbul output data to `cov-pt*/` directories with the `--dir` option, and made the initial parent process output to   `cov-pt0/` rather than `coverage/`. Then, I added a script to concatenate all the data together (with the istanbul API) and produce `coverage/`. It's not ideal, and if   you have a better solution please point out the solution.

There is also the problem for the watching mode test: when passing `SIGINT` (or `^C`) to jade when it is still watching the file, the exit handler is not called, therefore terminating istanbul as well. There is not another way of cleanly kill the process while it is watching I can think of, so I have added commit b079489 which makes `SIGINT` go through the exit handler. I do not expect it to change the behavior of `bin/jade.js` else than the return code, which callers would not depend on any way.

## To-do

With the changes applied, one can see that the coverage for `bin/jade.js` is not nearly as green as `lib/`. This is a to-do list for future improvements of test coverage:

Easier:
- Setting `--obj` to a file with JSON data
- Setting options in `--obj` (not just locals)
- Test compiling an entire directory
- Test specifying output dir with `--out`
- Test error handling for different things:
   - File not found

Harder:
- Test if `--help` works properly
- Test inclusion with `--path`
- Test error handling for different things:
   - `SIGINT` when reading from `stdin`
   - In watch mode (program should not terminate)