### PR TITLE
[VOTE] Better-looking badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Full documentation is at [jade-lang.com](http://jade-lang.com/)
 
  You can test drive Jade online [here](http://naltatis.github.com/jade-syntax-docs).
 
- [![Build Status](https://img.shields.io/travis/jadejs/jade/master.svg)](https://travis-ci.org/jadejs/jade)
- [![Dependency Status](https://img.shields.io/gemnasium/jadejs/jade.svg)](https://gemnasium.com/jadejs/jade)
- [![NPM version](https://img.shields.io/npm/v/jade.svg)](http://badge.fury.io/js/jade)
- [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/jadejs/jade?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+ [![Build Status](https://img.shields.io/travis/jadejs/jade/master.svg?style=flat)](https://travis-ci.org/jadejs/jade)
+ [![Dependency Status](https://img.shields.io/gemnasium/jadejs/jade.svg?style=flat)](https://gemnasium.com/jadejs/jade)
+ [![NPM version](https://img.shields.io/npm/v/jade.svg?style=flat)](http://badge.fury.io/js/jade)
+ [![Join Gitter Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat)](https://gitter.im/jadejs/jade?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Installation
 


### PR DESCRIPTION
1. Use flat style
2. Use badge from shields.io for Gitter chat

## shields.io update

According to http://shields.io (our badge provider), they are switching to a new default badge style:

> One of those two designs may become the default one. Vote by using them!

I am open for votes on the style of the badges:

- Flat style: [![Build Status](https://img.shields.io/travis/jadejs/jade/master.svg?style=flat)](https://travis-ci.org/jadejs/jade) [![Dependency Status](https://img.shields.io/gemnasium/jadejs/jade.svg?style=flat)](https://gemnasium.com/jadejs/jade) [![NPM version](https://img.shields.io/npm/v/jade.svg?style=flat)](http://badge.fury.io/js/jade) [![Join Gitter Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat)](https://gitter.im/jadejs/jade?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
- Flat-square style: [![Build Status](https://img.shields.io/travis/jadejs/jade/master.svg?style=flat-square)](https://travis-ci.org/jadejs/jade) [![Dependency Status](https://img.shields.io/gemnasium/jadejs/jade.svg?style=flat-square)](https://gemnasium.com/jadejs/jade) [![NPM version](https://img.shields.io/npm/v/jade.svg?style=flat-square)](http://badge.fury.io/js/jade) [![Join Gitter Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg?style=flat-square)](https://gitter.im/jadejs/jade?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

[ci skip]