### PR TITLE
No process uncaught exception

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -117,7 +117,7 @@ if (files.length) {
       }
       fs.watchFile(filename, {persistent: true, interval: 200},
                    function (curr, prev) {
-        if (curr.mtime === prev.mtime) return;
+        if (curr.mtime.getTime() === prev.mtime.getTime()) return;
         try {
           renderFile(filename);
         } catch (e) {

--- a/bin/jade.js
+++ b/bin/jade.js
@@ -109,16 +109,21 @@ if (files.length) {
   console.log();
   if (options.watch) {
     files.forEach(function(filename) {
-      // keep watching when error occured.
-      process.on('uncaughtException', function(err) {
-        console.error(err.stack
-                      || /* istanbul ignore next */ (err.message || err));
-      });
-      renderFile(filename);
+      try {
+        renderFile(filename);
+      } catch (e) {
+        // keep watching when error occured.
+        console.error(e.stack || e.message || e);
+      }
       fs.watchFile(filename, {persistent: true, interval: 200},
                    function (curr, prev) {
         if (curr.mtime === prev.mtime) return;
-        renderFile(filename);
+        try {
+          renderFile(filename);
+        } catch (e) {
+          // keep watching when error occured.
+          console.error(e.stack || e.message || e);
+        }
       });
     });
     process.on('SIGINT', function() {
@@ -169,45 +174,35 @@ function stdin() {
 
 function renderFile(path) {
   var re = /\.jade$/;
-  fs.lstat(path, function(err, stat) {
-    if (err) throw err;
-    // Found jade file
-    if (stat.isFile() && re.test(path)) {
-      fs.readFile(path, 'utf8', function(err, str){
-        if (err) throw err;
-        options.filename = path;
-        if (program.nameAfterFile) {
-          options.name = getNameFromFileName(path);
-        }
-        var fn = options.client ? jade.compileClient(str, options) : jade.compile(str, options);
-
-        // --extension
-        if (program.extension)   var extname = '.' + program.extension;
-        else if (options.client) var extname = '.js';
-        else                     var extname = '.html';
-
-        path = path.replace(re, extname);
-        if (program.out) path = join(program.out, basename(path));
-        var dir = resolve(dirname(path));
-        mkdirp(dir, 0755, function(err){
-          if (err) throw err;
-          var output = options.client ? fn : fn(options);
-          fs.writeFile(path, output, function(err){
-            if (err) throw err;
-            console.log('  \033[90mrendered \033[36m%s\033[0m', path);
-          });
-        });
-      });
-    // Found directory
-    } else if (stat.isDirectory()) {
-      fs.readdir(path, function(err, files) {
-        if (err) throw err;
-        files.map(function(filename) {
-          return path + '/' + filename;
-        }).forEach(renderFile);
-      });
+  var stat = fs.lstatSync(path);
+  // Found jade file/\.jade$/
+  if (stat.isFile() && re.test(path)) {
+    var str = fs.readFileSync(path, 'utf8');
+    options.filename = path;
+    if (program.nameAfterFile) {
+      options.name = getNameFromFileName(path);
     }
-  });
+    var fn = options.client ? jade.compileClient(str, options) : jade.compile(str, options);
+
+    // --extension
+    if (program.extension)   var extname = '.' + program.extension;
+    else if (options.client) var extname = '.js';
+    else                     var extname = '.html';
+
+    path = path.replace(re, extname);
+    if (program.out) path = join(program.out, basename(path));
+    var dir = resolve(dirname(path));
+    mkdirp.sync(dir, 0755);
+    var output = options.client ? fn : fn(options);
+    fs.writeFileSync(path, output);
+    console.log('  \033[90mrendered \033[36m%s\033[0m', path);
+  // Found directory
+  } else if (stat.isDirectory()) {
+    var files = fs.readdirSync(path);
+    files.map(function(filename) {
+      return path + '/' + filename;
+    }).forEach(renderFile);
+  }
 }
 
 /**

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -168,6 +168,10 @@ describe('command line watch mode', function () {
 
     watchProc.kill('SIGINT');
   });
+  afterEach(function (done) {
+    // jade --watch can only detect changes that are at least 1 second apart
+    setTimeout(done, 1000);
+  });
   it('jade --no-debug --client --name-after-file --watch input-file.jade (pass 1)', function (done) {
     if (isIstanbul) {
       this.timeout(6000);


### PR DESCRIPTION
This pull request contains 3 key changes:

1. This makes the CLI use synchronous code.  I very much doubt there is any real performance impact given that the jade rendering is the slow part and that was synchronous anyway.  It vastly simplifies the code, and in particular makes it way easier to do `--watch` mode.
2. It makes `--watch` mode use a `try/catch` block rather than `process.on('uncaughtException', ...)` (see the [node docs](http://nodejs.org/api/process.html#process_event_uncaughtexception) for why `process.on('uncaughtException', ...)` is a really bad idea here).
3. It adds a 1 second delay between each of the `--watch` tests.  This was necessary to get the tests passing on my mac (with or without the other two changes).  This is because the `mtime` of the files is only to the nearest second, so it won't rebuild files that change twice in a single second.  My guess is that the travis machine was just slow enough to get away with it.

Once this is merged, I will cut a new release as we have some significant bug fixes, but I don't want to release another version with `process.on('uncaughtException')`.