### PR TITLE
Cleanup coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
   },
   "scripts": {
     "test": "mocha -R spec && npm run coverage",
-    "coverage": "rimraf cov-pt* && istanbul cover --report none --dir cov-pt0 node_modules/mocha/bin/_mocha && istanbul report --include cov-pt\\*/coverage.json",
+    "precoverage": "rimraf coverage && rimraf cov-pt*",
+    "coverage": "istanbul cover --report none --dir cov-pt0 node_modules/mocha/bin/_mocha -- -R dot",
+    "postcoverage": "istanbul report --include cov-pt\\*/coverage.json && rimraf cov-pt*",
     "prepublish": "npm prune && linify transform bin && npm run build",
     "build": "npm run compile",
     "compile": "npm run compile-full && npm run compile-runtime",


### PR DESCRIPTION
This splits the coverage task out by adding “precoverage” and “postcoverage”.  It also deletes the intermediate coverage files once it is done.