### PR TITLE
Do not run coverage in `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     }
   },
   "scripts": {
-    "test": "mocha -R spec && npm run coverage",
+    "test": "mocha -R spec",
     "precoverage": "rimraf coverage && rimraf cov-pt*",
     "coverage": "istanbul cover --report none --dir cov-pt0 node_modules/mocha/bin/_mocha -- -R dot",
     "postcoverage": "istanbul report --include cov-pt\\*/coverage.json && rimraf cov-pt*",


### PR DESCRIPTION
Running coverage report is never the point of `test`.

See also https://github.com/jadejs/jade/pull/1820#issuecomment-69693312.