### PR TITLE
Jade CLI to Maintain Path Hierarchy (Another Attempt with Tests)

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -129,7 +129,9 @@ if (files.length) {
       process.exit(1);
     });
   } else {
-    files.forEach(renderFile);
+    files.forEach(function (file) {
+      renderFile(file);
+    });
   }
   process.on('exit', function () {
     console.log();
@@ -171,7 +173,7 @@ function stdin() {
  * Always walk the subdirectories.
  */
 
-function renderFile(path) {
+function renderFile(path, rootPath) {
   var re = /\.jade$/;
   var stat = fs.lstatSync(path);
   // Found jade file/\.jade$/
@@ -189,7 +191,13 @@ function renderFile(path) {
     else                     var extname = '.html';
 
     path = path.replace(re, extname);
-    if (program.out) path = join(program.out, basename(path));
+    if (program.out) {
+      if (typeof rootPath !== 'undefined') {
+        path = path.replace(rootPath, program.out);
+      } else {
+        path = join(program.out, basename(path));
+      }
+    }
     var dir = resolve(dirname(path));
     mkdirp.sync(dir, 0755);
     var output = options.client ? fn : fn(options);
@@ -200,7 +208,9 @@ function renderFile(path) {
     var files = fs.readdirSync(path);
     files.map(function(filename) {
       return path + '/' + filename;
-    }).forEach(renderFile);
+    }).forEach(function (file) {
+      renderFile(file, rootPath || path);
+    });
   }
 }
 

--- a/bin/jade.js
+++ b/bin/jade.js
@@ -193,7 +193,7 @@ function renderFile(path, rootPath) {
     path = path.replace(re, extname);
     if (program.out) {
       if (typeof rootPath !== 'undefined') {
-        path = path.replace(rootPath, program.out);
+        path = join(program.out, path.replace(rootPath, ''));
       } else {
         path = join(program.out, basename(path));
       }

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 var path = require('path');
 var assert = require('assert');
 var cp = require('child_process');
@@ -42,15 +43,9 @@ function run(args, stdin, callback) {
   }, callback);
 }
 
-['/temp', '/temp/inputs', '/temp/inputs/level-1-1', '/temp/inputs/level-1-2', '/temp/outputs'].forEach(function (path) {
-  try {
-    fs.mkdirSync(__dirname + path);
-  } catch (ex) {
-    if (ex.code !== 'EEXIST') {
-      throw ex;
-    }
-  }
-});
+mkdirp.sync(__dirname + '/temp/inputs/level-1-1');
+mkdirp.sync(__dirname + '/temp/inputs/level-1-2');
+mkdirp.sync(__dirname + '/temp/outputs');
 
 describe('command line with HTML output', function () {
   if (isIstanbul) {

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -45,7 +45,8 @@ function run(args, stdin, callback) {
 
 mkdirp.sync(__dirname + '/temp/inputs/level-1-1');
 mkdirp.sync(__dirname + '/temp/inputs/level-1-2');
-mkdirp.sync(__dirname + '/temp/outputs');
+mkdirp.sync(__dirname + '/temp/outputs/level-1-1');
+mkdirp.sync(__dirname + '/temp/outputs/level-1-2');
 
 describe('command line with HTML output', function () {
   if (isIstanbul) {

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -104,18 +104,20 @@ describe('command line with HTML output', function () {
   });
   context('when input is directory', function () {
     it('jade --no-debug --out outputs inputs', function (done) {
-      fs.writeFileSync(__dirname + '/temp/inputs/input.jade', '.foo bar-1');
-      fs.writeFileSync(__dirname + '/temp/inputs/level-1-1/input.jade', '.foo bar-1-1');
-      fs.writeFileSync(__dirname + '/temp/inputs/level-1-2/input.jade', '.foo bar-1-2');
-      fs.writeFileSync(__dirname + '/temp/input.js', 'throw new Error("output not written");');
+      fs.writeFileSync(__dirname + '/temp/inputs/input.jade', '.foo bar 1');
+      fs.writeFileSync(__dirname + '/temp/inputs/level-1-1/input.jade', '.foo bar 1-1');
+      fs.writeFileSync(__dirname + '/temp/inputs/level-1-2/input.jade', '.foo bar 1-2');
+      fs.writeFileSync(__dirname + '/temp/outputs/input.html', 'BIG FAT HEN 1');
+      fs.writeFileSync(__dirname + '/temp/outputs/level-1-1/input.html', 'BIG FAT HEN 1-1');
+      fs.writeFileSync(__dirname + '/temp/outputs/level-1-2/input.html', 'BIG FAT HEN 1-2');
       run('--no-debug --out outputs inputs', function (err) {
         if (err) return done(err);
         var html = fs.readFileSync(__dirname + '/temp/outputs/input.html', 'utf8');
-        assert(html === '<div class="foo">bar-1</div>');
+        assert(html === '<div class="foo">bar 1</div>');
         var html = fs.readFileSync(__dirname + '/temp/outputs/level-1-1/input.html', 'utf8');
-        assert(html === '<div class="foo">bar-1-1</div>');
+        assert(html === '<div class="foo">bar 1-1</div>');
         var html = fs.readFileSync(__dirname + '/temp/outputs/level-1-2/input.html', 'utf8');
-        assert(html === '<div class="foo">bar-1-2</div>');
+        assert(html === '<div class="foo">bar 1-2</div>');
         done();
       });
     });

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -103,7 +103,7 @@ describe('command line with HTML output', function () {
     });
   });
   context('when input is directory', function () {
-    it('jade --no-debug --client --out outputs inputs', function (done) {
+    it('jade --no-debug --out outputs inputs', function (done) {
       fs.writeFileSync(__dirname + '/temp/inputs/input.jade', '.foo bar-1');
       fs.writeFileSync(__dirname + '/temp/inputs/level-1-1/input.jade', '.foo bar-1-1');
       fs.writeFileSync(__dirname + '/temp/inputs/level-1-2/input.jade', '.foo bar-1-2');


### PR DESCRIPTION
Change jade cli to keep subdirectory structure in output directory.

I've seen several attempts to solve this problem #820, #822, #1525 but none got merged eventually. Here's my attempt to bring this feature to Jade CLI. Tests have been added to make sure everything's ok.