### PR TITLE
Add warning for `:` not followed by a space

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -223,6 +223,10 @@ Lexer.prototype = {
         name = name.slice(0, -1);
         tok = this.tok('tag', name);
         this.defer(this.tok(':'));
+        if (this.input[0] !== ' ') {
+          console.warn('Warning: space required after `:` on line ' + this.lineno +
+              ' of jade file "' + this.filename + '"');
+        }
         while (' ' == this.input[0]) this.input = this.input.substr(1);
       } else {
         tok = this.tok('tag', name);
@@ -868,7 +872,13 @@ Lexer.prototype = {
    */
 
   colon: function() {
-    return this.scan(/^: */, ':');
+    var good = /^: +/.test(this.input);
+    var res = this.scan(/^: */, ':');
+    if (res && !good) {
+      console.warn('Warning: space required after `:` on line ' + this.lineno +
+          ' of jade file "' + this.filename + '"');
+    }
+    return res;
   },
 
   fail: function () {


### PR DESCRIPTION
Lets disallow `:` without a space after it as part of the move to 2.0.0.  It would catch #1514 and also makes it easier to tell the difference between `:` and `:filter` when reading jade code (and parsing jade code).