### PR TITLE
Add `compileClientWithDependenciesTracked`

### DIFF
--- a/docs/views/api.jade
+++ b/docs/views/api.jade
@@ -133,6 +133,21 @@ block content
       // Render the function
       var html = fn(locals);
       // => 'function template(locals) { return "<string>of jade</string>"; }'
+  
+  h3 jade.compileClientWithDependenciesTracked(source, options)
+  
+  p See #[code jade.compileClient] except that this method returns an object of the form:
+  
+  +js
+    :jssrc
+      {
+        'body': 'function (locals) {...}',
+        'dependencies': ['filename.jade']
+      }
+
+  p.
+    You should only use this method if you need to implement something
+    like watching for changes to the jade files.
 
   h3 jade.render(source, options)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,34 +239,52 @@ exports.compile = function(str, options){
  *
  * @param {String} str
  * @param {Options} options
- * @return {String}
+ * @return {Object}
  * @api public
  */
 
-exports.compileClient = function(str, options){
+exports.compileClientWithDependenciesTracked = function(str, options){
   var options = options || {};
   var name = options.name || 'template';
   var filename = options.filename ? utils.stringify(options.filename) : 'undefined';
   var fn;
 
   str = String(str);
-
+  options.compileDebug = options.compileDebug ? true : false;
+  var parsed = parse(str, options);
   if (options.compileDebug) {
-    options.compileDebug = true;
     fn = [
         'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
       , 'try {'
-      , parse(str, options).body
+      , parsed.body
       , '} catch (err) {'
       , '  jade.rethrow(err, jade_debug[0].filename, jade_debug[0].lineno, ' + utils.stringify(str) + ');'
       , '}'
     ].join('\n');
   } else {
-    options.compileDebug = false;
-    fn = parse(str, options).body;
+    fn = parsed.body;
   }
 
-  return 'function ' + name + '(locals) {\n' + fn + '\n}';
+  return {body: 'function ' + name + '(locals) {\n' + fn + '\n}', dependencies: parsed.dependencies};
+};
+
+/**
+ * Compile a JavaScript source representation of the given jade `str`.
+ *
+ * Options:
+ *
+ *   - `compileDebug` When it is `true`, the source code is included in
+ *     the compiled template for better error messages.
+ *   - `filename` used to improve errors when `compileDebug` is not `true` and to resolve imports/extends
+ *   - `name` the name of the resulting function (defaults to "template")
+ *
+ * @param {String} str
+ * @param {Options} options
+ * @return {String}
+ * @api public
+ */
+exports.compileClient = function (str, options) {
+  return exports.compileClientWithDependenciesTracked(str, options).body;
 };
 
 /**


### PR DESCRIPTION
[fixes #1705]

The name of the new API is fairly long and clunky, but it should only be used by build tools like jadeify.  I think this is therefore the simplest way to implement this.