### PR TITLE
Add support for comments in a case block

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -297,6 +297,7 @@ Parser.prototype = {
     this.expect('indent');
     while ('outdent' != this.peek().type) {
       switch (this.peek().type) {
+        case 'comment':
         case 'newline':
           this.advance();
           break;

--- a/test/cases/comments-in-case.html
+++ b/test/cases/comments-in-case.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>It's this!</p>
+  </body>
+</html>

--- a/test/cases/comments-in-case.jade
+++ b/test/cases/comments-in-case.jade
@@ -1,0 +1,10 @@
+doctype html
+html
+  body
+   - var s = 'this'
+   case s
+     //- Comment
+     when 'this'
+       p It's this!
+     when 'that'
+       p It's that!


### PR DESCRIPTION
[fixes #1707]

This treats both buffered and unbuffered comments as unbuffered comments.  I don't think that matters though.