### PR TITLE
Fixes for watch mode.

### DIFF
--- a/bin/jade.js
+++ b/bin/jade.js
@@ -115,12 +115,8 @@ if (files.length) {
     process.on('SIGINT', function() {
       process.exit(1);
     });
-    // unwatch what's watched on exit
-    process.on("exit", function () {
-      watchList.forEach(fs.unwatchFile);
-    });
   }
-  files.forEach(renderFile);
+  files.forEach(options.watch ? tryRender : renderFile);
   process.on('exit', function () {
     console.log();
   });

--- a/bin/jade.js
+++ b/bin/jade.js
@@ -218,7 +218,7 @@ function renderFile(path) {
       options.name = getNameFromFileName(path);
     }
     var fn = options.client ? jade.compileClient(str, options) : jade.compile(str, options);
-    if (fn.dependencies) {
+    if (options.watch && fn.dependencies) {
       // watch dependencies, and recompile the base
       fn.dependencies.forEach(function (dep) {
         watchFile(dep, path);

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -50,14 +50,21 @@ try {
   }
 }
 
-describe('command line', function () {
+/**
+ * Set timing limits for a test case
+ */
+function timing(testCase) {
   if (isIstanbul) {
-    this.timeout(60000);
-    this.slow(6000);
+    testCase.timeout(20000);
+    testCase.slow(3000);
   } else {
-    this.timeout(30000);
-    this.slow(3000);
+    testCase.timeout(12500);
+    testCase.slow(2000);
   }
+}
+
+describe('command line', function () {
+  timing(this);
   it('jade --version', function (done) {
     run('-V', function (err, stdout) {
       if (err) done(err);
@@ -82,13 +89,7 @@ describe('command line', function () {
 });
 
 describe('command line with HTML output', function () {
-  if (isIstanbul) {
-    this.timeout(60000);
-    this.slow(6000);
-  } else {
-    this.timeout(30000);
-    this.slow(3000);
-  }
+  timing(this);
   it('jade --no-debug input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
     fs.writeFileSync(__dirname + '/temp/input.html', '<p>output not written</p>');
@@ -141,13 +142,7 @@ describe('command line with HTML output', function () {
 });
 
 describe('command line with client JS output', function () {
-  if (isIstanbul) {
-    this.timeout(60000);
-    this.slow(6000);
-  } else {
-    this.timeout(30000);
-    this.slow(3000);
-  }
+  timing(this);
   it('jade --no-debug --client --name myTemplate input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
     fs.writeFileSync(__dirname + '/temp/input.js', 'throw new Error("output not written");');
@@ -217,13 +212,7 @@ describe('command line watch mode', function () {
     setTimeout(done, 1000);
   });
   it('jade --no-debug --client --name-after-file --watch input-file.jade (pass 1)', function (done) {
-    if (isIstanbul) {
-      this.timeout(60000);
-      this.slow(6000);
-    } else {
-      this.timeout(30000);
-      this.slow(3000);
-    }
+    timing(this);
     fs.writeFileSync(__dirname + '/temp/input-file.jade', '.foo bar');
     fs.writeFileSync(__dirname + '/temp/input-file.js', 'throw new Error("output not written (pass 1)");');
     var cmd = getRunner();

--- a/test/command-line.js
+++ b/test/command-line.js
@@ -52,10 +52,11 @@ try {
 
 describe('command line', function () {
   if (isIstanbul) {
-    this.timeout(11000);
-    this.slow(9000);
+    this.timeout(60000);
+    this.slow(6000);
   } else {
-    this.slow(250);
+    this.timeout(30000);
+    this.slow(3000);
   }
   it('jade --version', function (done) {
     run('-V', function (err, stdout) {
@@ -82,10 +83,11 @@ describe('command line', function () {
 
 describe('command line with HTML output', function () {
   if (isIstanbul) {
-    this.timeout(8000);
+    this.timeout(60000);
     this.slow(6000);
   } else {
-    this.slow(250);
+    this.timeout(30000);
+    this.slow(3000);
   }
   it('jade --no-debug input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
@@ -140,10 +142,11 @@ describe('command line with HTML output', function () {
 
 describe('command line with client JS output', function () {
   if (isIstanbul) {
-    this.timeout(8000);
+    this.timeout(60000);
     this.slow(6000);
   } else {
-    this.slow(250);
+    this.timeout(30000);
+    this.slow(3000);
   }
   it('jade --no-debug --client --name myTemplate input.jade', function (done) {
     fs.writeFileSync(__dirname + '/temp/input.jade', '.foo bar');
@@ -215,10 +218,11 @@ describe('command line watch mode', function () {
   });
   it('jade --no-debug --client --name-after-file --watch input-file.jade (pass 1)', function (done) {
     if (isIstanbul) {
-      this.timeout(8000);
+      this.timeout(60000);
       this.slow(6000);
     } else {
-      this.slow(300);
+      this.timeout(30000);
+      this.slow(3000);
     }
     fs.writeFileSync(__dirname + '/temp/input-file.jade', '.foo bar');
     fs.writeFileSync(__dirname + '/temp/input-file.js', 'throw new Error("output not written (pass 1)");');


### PR DESCRIPTION
Problems that are fixed in the request:

1. #1086
2. problem, that when watching a folder jade-cli was not watching subtrees.

Solutions provided:

1. fetch dependencies from ```jade.compile```, and watch'em.
2. watch every file that is a target for render.

Improvement:

1. Unwatching a file, if the file was moved or removed.
