### PR TITLE
Travis: test with io.js 1.1 instead of Node.js 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
+  - "0.12"
+  - "iojs-1.1"
 
 # Use faster Docker architecture on Travis.
 sudo: false


### PR DESCRIPTION
Node.js 0.11 is dead.