### PR TITLE
(docs) sanatize->sanitize

### DIFF
--- a/docs/views/reference/attributes.jade
+++ b/docs/views/reference/attributes.jade
@@ -66,7 +66,7 @@ block documentation
     .panel-body
       p.
         Unescaped buffered code can be dangerous.
-        You must be sure to sanatize any user inputs to avoid
+        You must be sure to sanitize any user inputs to avoid
         #[a(href='http://en.wikipedia.org/wiki/Cross-site_scripting') Cross Site Scripting]
 
   h2#booleanattribs Boolean Attributes
@@ -239,6 +239,6 @@ block documentation
     .panel-body
       p.
         Attributes applied using #[code &amp;attributes] are not automatically escaped.
-        You must be sure to sanatize any user inputs to avoid
+        You must be sure to sanitize any user inputs to avoid
         #[a(href='http://en.wikipedia.org/wiki/Cross-site_scripting') Cross Site Scripting].
         This is done for you if you are passing in #[code attributes] from a mixin call.

--- a/docs/views/reference/code.jade
+++ b/docs/views/reference/code.jade
@@ -82,5 +82,5 @@ block documentation
     .panel-body
       p.
         Unescaped buffered code can be dangerous.
-        You must be sure to sanatize any user inputs to avoid
+        You must be sure to sanitize any user inputs to avoid
         #[a(href='http://en.wikipedia.org/wiki/Cross-site_scripting') Cross Site Scripting]


### PR DESCRIPTION
- Fixes a typo in the documentation (sanatize ->  sanitize).