### PR TITLE
Added debugLines option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Thiis is a for of Jade that adds a new debug option: `debugLines`.
+
 # [![Jade - Node Template Engine](http://jade-lang.com/logos/JadeBlack.svg)](http://jade-lang.com/)
 
 Full documentation is at [jade-lang.com](http://jade-lang.com/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Thiis is a for of Jade that adds a new debug option: `debugLines`.
-
 # [![Jade - Node Template Engine](http://jade-lang.com/logos/JadeBlack.svg)](http://jade-lang.com/)
 
 Full documentation is at [jade-lang.com](http://jade-lang.com/)

--- a/docs/views/api.jade
+++ b/docs/views/api.jade
@@ -51,6 +51,12 @@ block content
       dt globals:
       dd.type.array= 'Array.<string>'
       dd.description Add a list of global names to make accessible in templates
+      dt debugLines:
+      dd.type.string string
+      dd.description Adds #[code data-jade-file] and #[code data-jade-line] attributes to the generated HTML elements. This indicates the source jade 
+        | template file name and the line number that generated that HTML element. To minimize the size of the output not all 
+        | elements contain this information. If a node doesn't have any of these attributes it means that the inforation will be found in 
+        | one of its ancestors.
     div }
 
   h3 jade.compile(source, options)

--- a/examples/includes.js
+++ b/examples/includes.js
@@ -6,6 +6,6 @@
 var jade = require('../')
   , path = __dirname + '/includes.jade'
   , str = require('fs').readFileSync(path, 'utf8')
-  , fn = jade.compile(str, { filename: path, pretty: true });
+  , fn = jade.compile(str, { filename: path, pretty: true, debugLines: true });
 
 console.log(fn());

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -211,7 +211,9 @@ Compiler.prototype = {
       this.buf.pop();
     }
 
+    var last = this.lastFilename;
     this.visitNode(node);
+    this.lastFilename = last;
 
     if (debug) this.buf.push('jade_debug.shift();');
   },
@@ -421,7 +423,6 @@ Compiler.prototype = {
       var mixin_end = this.buf.length;
       this.mixins[key].instances.push({start: mixin_start, end: mixin_end});
     }
-    this.lastFilename = null;
   },
 
   /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -462,12 +462,12 @@ Compiler.prototype = {
       bufferName();
       if (self.debugLines && tag.filename && tag.line) {
         if (tag.filename !== self.lastFilename) {
-          self.buffer(' jade_file="');
+          self.buffer(' data-jade-file="');
           self.buffer(tag.filename);
           self.buffer('"');
           self.lastFilename = tag.filename;
         }
-        self.buffer(' jade_line=');
+        self.buffer(' data-jade-line=');
         self.buffer(String(tag.line));
       }
     }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -44,6 +44,8 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.terse = false;
   this.mixins = {};
   this.dynamicMixins = false;
+  this.debugLines = options.debugLines || false;
+  this.lastFilename = null;
   if (options.doctype) this.setDoctype(options.doctype);
 };
 
@@ -419,6 +421,7 @@ Compiler.prototype = {
       var mixin_end = this.buf.length;
       this.mixins[key].instances.push({start: mixin_start, end: mixin_end});
     }
+    this.lastFilename = null;
   },
 
   /**
@@ -453,9 +456,23 @@ Compiler.prototype = {
     if (pp && !tag.isInline())
       this.prettyIndent(0, true);
 
-    if (tag.selfClosing || (!this.xml && selfClosing[tag.name])) {
-      this.buffer('<');
+    function startTag() {
+      self.buffer('<');
       bufferName();
+      if (self.debugLines && tag.filename && tag.line) {
+        if (tag.filename !== self.lastFilename) {
+          self.buffer(' jade_file="');
+          self.buffer(tag.filename);
+          self.buffer('"');
+          self.lastFilename = tag.filename;
+        }
+        self.buffer(' jade_line=');
+        self.buffer(String(tag.line));
+      }
+    }
+
+    if (tag.selfClosing || (!this.xml && selfClosing[tag.name])) {
+      startTag();
       this.visitAttributes(tag.attrs, tag.attributeBlocks.slice());
       this.terse
         ? this.buffer('>')
@@ -470,8 +487,7 @@ Compiler.prototype = {
       }
     } else {
       // Optimize attributes buffering
-      this.buffer('<');
-      bufferName();
+      startTag();
       this.visitAttributes(tag.attrs, tag.attributeBlocks.slice());
       this.buffer('>');
       if (tag.code) this.visitCode(tag.code);


### PR DESCRIPTION
I want to create a middleware for express and jade. I'll publish it as a separate module. This module allows me to interactively open a text editor by selecting a DOM node in the browser. The text editor is opened in exactly the file and line that generated that DOM node. What I need from jade is to add an option to include filenames and line numbers in the HTML output. I've done an initial implementation. If the idea is accepted I will write tests for that.

This is how the output with this option enabled looks like:

```html
<html jade_file="/path/to/jade/examples/includes.jade" jade_line=2>
  <head jade_file="/path/to/jade/examples/includes/head.jade" jade_line=1>
    <title jade_line=2>My Site</title>
    <!-- including other jade works-->
    <script jade_file="/path/to/jade/examples/includes/scripts.jade" jade_line=1 src="/javascripts/jquery.js"></script>
    <script jade_line=2 src="/javascripts/app.js"></script>
    <!-- including .html, .css, etc works--><style>
  body {
    padding: 50px;
  }
</style>
  </head>
  <body jade_file="/path/to/jade/examples/includes.jade" jade_line=4>
    <h1 jade_line=5>My Site</h1>
    <p jade_line=6>Welcome to my super lame site.</p>
    <div jade_file="/path/to/jade/examples/includes/foot.jade" jade_line=1 id="footer">
      <p jade_line=2>Copyright (c) foobar</p>
    </div>
  </body>
</html>
```

This is a video of the feature I've built https://vimeo.com/121122160

As you can see there is a debug mode that can be toggled with a combination of key strokes and then by clicking on a DOM node the text editor opens in the file and line that generated the output. Which is going to save me A LOT of time.

As I said I only need some debug information in the HTML output. If the flag/idea is accepted to be included in jade to output this information I will complete this pull request with a new commit adding unit tests.

Thanks!