### PR TITLE
Add parser support for inline filters like #[:link home]

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -684,6 +684,12 @@ Parser.prototype = {
     var block = new nodes.Block;
     block.line = this.line();
     var body = this.peek();
+    if (body.type === 'text') {
+      var text = new nodes.Text(this.expect('text').val);
+      text.line = block.line;
+      block.push(text);
+      return block;
+    }
     if (body.type !== 'pipeless-text') return;
     this.advance();
     block.nodes = body.val.reduce(function (accumulator, text) {

--- a/test/cases/filters.inline.html
+++ b/test/cases/filters.inline.html
@@ -1,0 +1,1 @@
+<p>before <![CDATA[inside]]> after</p>

--- a/test/cases/filters.inline.jade
+++ b/test/cases/filters.inline.jade
@@ -1,0 +1,1 @@
+p before #[:cdata inside] after


### PR DESCRIPTION
I found myself wanting support for filters inside interpolation nodes. I'm not sure if this feature was intentionally omitted but if not it seems easy to add. I found this feature useful for generating and verifying internal links among templates, sort of like links inside a wiki. If this pull request isn't useful then feel free to close it.
