### PR TITLE
Grammar fixes.

### DIFF
--- a/docs/views/reference/interpolation.jade
+++ b/docs/views/reference/interpolation.jade
@@ -119,6 +119,6 @@ block documentation
 
   p.
     You could accomplish the same thing by writing an HTML tag inline with your
-    Jade, but then, what's the point of writing the Jade? Wrap an inline Jade
+    Jade, but then what's the point of writing the Jade? Wrap an inline Jade
     tag declaration in <code>\#[</code> and <code>]</code> and it'll be evaluated
-    and buffered into the content of it's containing tag.
+    and buffered into the content of its containing tag.


### PR DESCRIPTION
Use possessive form of "its" rather than "it's". Removed an unnecessary (read: ungrammatical) comma from same paragraph.