### PR TITLE
no value attributes are rendered differently

### DIFF
--- a/test/cases/attr-no-value-mixin.html
+++ b/test/cases/attr-no-value-mixin.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <div ui-view></div>
+  </body>
+</html>

--- a/test/cases/attr-no-value-mixin.jade
+++ b/test/cases/attr-no-value-mixin.jade
@@ -1,0 +1,4 @@
+include auxiliary/mixin-attr-no-value
+doctype html
+html
+  +attr-mixin()

--- a/test/cases/attr-no-value-simple.html
+++ b/test/cases/attr-no-value-simple.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <div ui-view></div>
+  </body>
+</html>

--- a/test/cases/attr-no-value-simple.jade
+++ b/test/cases/attr-no-value-simple.jade
@@ -1,0 +1,5 @@
+doctype html
+html
+  head
+  body
+    div(ui-view)

--- a/test/cases/auxiliary/mixin-attr-no-value.jade
+++ b/test/cases/auxiliary/mixin-attr-no-value.jade
@@ -1,0 +1,4 @@
+mixin attr-mixin
+  head
+  body
+    div(ui-view)


### PR DESCRIPTION
depending on wether it is done via included mixin or directly.

see `<div ui-view></div>` in the example