### PR TITLE
allow dots in tag names (for xml documents only)

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -211,7 +211,7 @@ Lexer.prototype = {
 
   tag: function() {
     var captures;
-    if (captures = /^(\w[-:\w]*)(\/?)/.exec(this.input)) {
+    if (captures = (this.doctype === 'xml' ? /^(\w[\.-:\w]*)(\/?)/ : /^(\w[-:\w]*)(\/?)/).exec(this.input)) {
       this.consume(captures[0].length);
       var tok, name = captures[1];
       if (':' == name[name.length - 1]) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,6 +30,7 @@ var Parser = exports = module.exports = function Parser(str, filename, options){
   this.inMixin = 0;
   this.dependencies = [];
   this.inBlock = 0;
+  this.lexer.doctype = options.doctype;
 };
 
 /**


### PR DESCRIPTION
Some xml-based APIs use "." in tag names, for example Google Adwords (SOAP). As I know, "class" attribute has no meaning like it has in html documents, but still can be added in jade like this ```some:tag.type(class="type")```. My pull request works if ```doctype: 'xml'``` is specified in ```compile, renderFile, ...``` options.