### PR TITLE
fixed memory leak caused by compileDebug flag

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -195,11 +195,11 @@ Compiler.prototype = {
     var debug = this.debug;
 
     if (debug) {
-      this.buf.push('jade_debug.unshift({ lineno: ' + node.line
-        + ', filename: ' + (node.filename
+      this.buf.push('jade_debug.unshift(new jade.DebugItem( ' + node.line
+        + ', ' + (node.filename
           ? utils.stringify(node.filename)
           : 'jade_debug[0].filename')
-        + ' });');
+        + ' ));');
     }
 
     // Massive hack to fix our context

--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,7 @@ exports.compile = function(str, options){
   var parsed = parse(str, options);
   if (options.compileDebug !== false) {
     fn = [
-        'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
+        'var jade_debug = [ new jade.DebugItem( 1, ' + filename + ' ) ];'
       , 'try {'
       , parsed.body
       , '} catch (err) {'
@@ -256,7 +256,7 @@ exports.compileClientWithDependenciesTracked = function(str, options){
   var parsed = parse(str, options);
   if (options.compileDebug) {
     fn = [
-        'var jade_debug = [{ lineno: 1, filename: ' + filename + ' }];'
+        'var jade_debug = [ new jade.DebugItem( 1, ' + filename + ' ) ];'
       , 'try {'
       , parsed.body
       , '} catch (err) {'

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -230,3 +230,8 @@ exports.rethrow = function rethrow(err, filename, lineno, str){
     + '\n' + context + '\n\n' + err.message;
   throw err;
 };
+
+exports.DebugItem = function DebugItem(lineno, filename) {
+  this.lineno = lineno;
+  this.filename = filename;
+}

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,6 +1,7 @@
 
 var runtime = require('../lib/runtime')
-  , merge = runtime.merge;
+  , merge = runtime.merge
+  , DebugItem = runtime.DebugItem;
 
 describe('merge(a, b, escaped)', function(){
   it('should merge classes into strings', function(){
@@ -36,5 +37,12 @@ describe('merge(a, b, escaped)', function(){
 
     merge({ class: ['foo', null, 'bar'] }, { class: [undefined, null, 0, 'baz'] })
       .should.eql({ class: ['foo', 'bar', 0, 'baz'] });
+  })
+})
+
+describe('DebugItem', function(){
+  it('should instantiate objects with lineno and filename properties', function(){
+    new DebugItem(42, "/path/to/file")
+      .should.eql({ lineno: 42, filename: "/path/to/file" });
   })
 })


### PR DESCRIPTION
Details and code showing the leak: https://github.com/alubbe/memoryleak
In-browser demo: https://alubbe.github.io/memoryleak/

This leak has been bugging me since I updated node from 0.11.13 to 0.11.14. It has affected all my apps and causes them to take up over a gig of ram per process after a few days. Also, the constant GC makes the app slower and slower with each passing hour.

After forcing the processes to restart every day and also seeing the huge performance regression express received in the last Techempower benchmarks, I got fed up enough to go and track down the issue. First, I started to pre-compile the templates during the build step, and eval'ing the files' contents. This completely fixed any issues I had. So I started working on a new express middleware and just as I was about to publish it, I diffed its implementation to jade's own .compile() and found almost no difference.

That's when it hit me - compileDebug is still enabled by default, even in production. Disabling it via ```app.locals.compileDebug  = false``` brought jade's performance to the level of my own implementation. So I scrapped my middleware and started to profile jade with heapdumps when compileDebug is enabled. Weirdly enough, the resulting 500mb process had a heapdump of 3mb. According to v8, everything had been successfully GC'ed. So I embarked on an epic 'comment-out-all-the-things!!!' journey and somehow figured out that the issue is with the object allocation into the jade_debug array, specifically, these kinds of lines:
```js
var jade_debug = [{ lineno: 1, filename: "/home/andreas/code/sampleexpress/views/fortunes/index.jade" }];
jade_debug.unshift({ lineno: 0, filename: "/home/andreas/code/sampleexpress/views/layout.jade" });
```
It seems that since node 0.11.13, v8 has forgotten to identify the shared hidden class of the ```{lineno: Integer, filename: String}``` objects. So I made it explicit by conjuring up a DebugItem and voilà, the memory leak is gone.

I'm raising this issue with v8 directly as well (https://code.google.com/p/v8/issues/detail?id=4121), but in the meantime I believe jade should fix it locally because this memory leak exists on node > 0.11.14, 0.12.* and all iojs releases.

I would also like to discuss disabling compileDebug for express' production environment by default, since you already recommend this in the documentation - but that's for a different PR ;)

Looking forward to hear your feedback!