### PR TITLE
disable compileDebug for express' production env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -410,4 +410,9 @@ exports.compileFileClient = function(path, options){
  * Express support.
  */
 
-exports.__express = exports.renderFile;
+exports.__express = function(path, options, fn) {
+  if(options.compileDebug == undefined && process.env.NODE_ENV === 'production') {
+    options.compileDebug = false;
+  }
+  exports.renderFile(path, options, fn);
+}


### PR DESCRIPTION
Building on the discussion in https://github.com/jadejs/jade/pull/1951, I would recommend to disable compileDebug by default for express' production env.

That's really all there is to it - what do you think?