### PR TITLE
updated tests to work with new version of v8

### DIFF
--- a/test/error.reporting.js
+++ b/test/error.reporting.js
@@ -54,7 +54,7 @@ describe('error reporting', function () {
       it('includes detail of where the error was thrown including the filename', function () {
         var err = getFileError(__dirname + '/fixtures/compile.with.layout.locals.error.jade', {})
         assert(/[\\\/]layout.locals.error.jade:2/.test(err.message))
-        assert(/undefined is not a function/.test(err.message))
+        assert(/is not a function/.test(err.message))
       });
     });
     describe('with a include (syntax)', function () {


### PR DESCRIPTION
The error messages produced by v8 now included the variable name, so what before was
```
undefined is not a function
```
is now
```
foo is not a function
```
The test has been changed to reflect that.
