### PR TITLE
Added block code support

### DIFF
--- a/docs/views/reference/code.jade
+++ b/docs/views/reference/code.jade
@@ -21,6 +21,27 @@ block documentation
           <li>item</li>
           <li>item</li>
           <li>item</li>
+  
+  p Jade also supports block unbuffered code:
+  
+  .row(data-control='interactive')
+    .col-lg-6
+      +jade
+        :jadesrc
+          -
+            list = ["Uno", "Dos", "Tres",
+                    "Cuatro", "Cinco", "Seis"]
+          each item in list
+            li item
+    .col-lg-6
+      +html
+        :htmlsrc
+          <li>Uno</li>
+          <li>Dos</li>
+          <li>Tres</li>
+          <li>Cuatro</li>
+          <li>Cinco</li>
+          <li>Seis</li>
 
   h2 Buffered Code
 

--- a/docs/views/reference/code.jade
+++ b/docs/views/reference/code.jade
@@ -32,7 +32,7 @@ block documentation
             list = ["Uno", "Dos", "Tres",
                     "Cuatro", "Cinco", "Seis"]
           each item in list
-            li item
+            li= item
     .col-lg-6
       +html
         :htmlsrc

--- a/examples/code.jade
+++ b/examples/code.jade
@@ -1,7 +1,12 @@
 
 - var title = "Things"
 
+-
+  var subtitle = ["Really",  "long",
+                  "list", "of",
+                  "words"]
 h1= title
+h2= subtitle.join(" ")
 
 ul#users
   each user, name in users

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -586,6 +586,21 @@ Lexer.prototype = {
     }
   },
 
+
+  /**
+   * Block code.
+   */
+
+  blockCode: function() {
+    var captures;
+    if (captures = /^-[ \t]*(\n|$)/.exec(this.input)) {
+      this.consume(captures[0].length - captures[1].length);
+      var tok = this.tok('blockCode');
+      this.pipeless = true;
+      return tok;
+    }
+  },
+
   /**
    * Attributes.
    */
@@ -916,6 +931,7 @@ Lexer.prototype = {
       || this["while"]()
       || this.tag()
       || this.filter()
+      || this.blockCode()
       || this.code()
       || this.id()
       || this.className()

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -593,8 +593,8 @@ Lexer.prototype = {
 
   blockCode: function() {
     var captures;
-    if (captures = /^-[ \t]*(\n|$)/.exec(this.input)) {
-      this.consume(captures[0].length - captures[1].length);
+    if (captures = /^-\n/.exec(this.input)) {
+      this.consume(captures[0].length - 1);
       var tok = this.tok('blockCode');
       this.pipeless = true;
       return tok;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -233,6 +233,8 @@ Parser.prototype = {
         return this.parseEach();
       case 'code':
         return this.parseCode();
+      case 'blockCode':
+        return this.parseBlockCode();
       case 'call':
         return this.parseCall();
       case 'interpolation':
@@ -376,6 +378,25 @@ Parser.prototype = {
     return node;
   },
 
+  /**
+   * block code
+   */
+
+  parseBlockCode: function(){
+    var tok = this.expect('blockCode');
+    var node;
+    var body = this.peek();
+    var text;
+    if (body.type === 'pipeless-text') {
+      this.advance();
+      text = body.val.join('\n');
+    } else {
+      text = '';
+    }
+      node = new nodes.Code(text, false, false);
+      return node;
+  },
+  
   /**
    * comment
    */

--- a/test/cases/block-code.html
+++ b/test/cases/block-code.html
@@ -1,0 +1,7 @@
+
+<li>Uno</li>
+<li>Dos</li>
+<li>Tres</li>
+<li>Cuatro</li>
+<li>Cinco</li>
+<li>Seis</li>

--- a/test/cases/block-code.jade
+++ b/test/cases/block-code.jade
@@ -1,6 +1,8 @@
 -
   list = ["uno", "dos", "tres",
           "cuatro", "cinco", "seis"];
+//- Without a block, the element is accepted and no code is generated
+-
 each item in list
   -
     string = item.charAt(0)

--- a/test/cases/block-code.jade
+++ b/test/cases/block-code.jade
@@ -1,0 +1,10 @@
+-
+  list = ["uno", "dos", "tres",
+          "cuatro", "cinco", "seis"];
+each item in list
+  -
+    string = item.charAt(0)
+    
+      .toUpperCase() +
+    item.slice(1);
+  li= string

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -686,7 +686,8 @@ describe('jade', function(){
           '-',
           '  var a =',
           '    5;',
-          'p= a'
+          'p= a',
+          '-'
       ].join('\n')
 
       var html = [

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -681,6 +681,19 @@ describe('jade', function(){
       ].join('');
 
       assert.equal(html, jade.render(str));
+      
+      var str = [
+          '-',
+          '  var a =',
+          '    5;',
+          'p= a'
+      ].join('\n')
+
+      var html = [
+          '<p>5</p>'
+      ].join('');
+
+      assert.equal(html, jade.render(str));
     });
 
     it('should support - each', function(){

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -686,8 +686,7 @@ describe('jade', function(){
           '-',
           '  var a =',
           '    5;',
-          'p= a',
-          '-'
+          'p= a'
       ].join('\n')
 
       var html = [


### PR DESCRIPTION
Added support for multi-line JS code as discussed in [pull request #796.](https://github.com/jadejs/jade/issues/796#issuecomment-39235865)

Block code starts with a line containing only '-', possibly with trailing whitespace. A block after that line is treated as unbuffered Javascript code, such as:

    -
      var arr = ["Very", "Long",
                 "Array"];

Changed tests and docs accordingly.

Please let me know if there are any issues - thank you.