### PR TITLE
Better line number counting for pipeless text

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -845,6 +845,7 @@ Lexer.prototype = {
         if (isMatch) {
           // consume test along with `\n` prefix if match
           this.consume(str.length + 1);
+          ++this.lineno;
           tokens.push(str.substr(indent.length));
         }
       } while(this.input.length && isMatch);

--- a/test/jade.test.js
+++ b/test/jade.test.js
@@ -881,6 +881,32 @@ describe('jade', function(){
       assert.equal("<p>foo\u2028bar</p>", jade.render("p foo\u2028bar"));
       assert.equal("<p>foo\u2029bar</p>", jade.render("p foo\u2029bar"));
     });
+    
+    it('should display error line number correctly up to token level', function() {
+      var str = [
+        'p.',
+        '  Lorem ipsum dolor sit amet, consectetur',
+        '  adipisicing elit, sed do eiusmod tempor',
+        '  incididunt ut labore et dolore magna aliqua.',
+        'p.',
+        '  Ut enim ad minim veniam, quis nostrud',
+        '  exercitation ullamco laboris nisi ut aliquip',
+        '  ex ea commodo consequat.',
+        'p.',
+        '  Duis aute irure dolor in reprehenderit',
+        '  in voluptate velit esse cillum dolore eu',
+        '  fugiat nulla pariatur.',
+        'a(href="#" Next',
+      ].join('\n');
+      var errorLocation = function(str) {
+        try {
+          jade.render(str);
+        } catch (err) {
+          return err.message.split('\n')[0];
+        }
+      };
+      assert.equal(errorLocation(str), "Jade:13");
+    });
   });
 
   describe('.compileFile()', function () {


### PR DESCRIPTION
In the current version, pipeless text is not included in the line count used in error messages, which makes errors in pages rich with such text annoyingly difficult to track, e. g.:

    p.
      Lorem ipsum dolor sit amet, consectetur  
      adipisicing elit, sed do eiusmod tempor 
      incididunt ut labore et dolore magna aliqua. 
    p.
      Ut enim ad minim veniam, quis nostrud 
      exercitation ullamco laboris nisi ut aliquip 
      ex ea commodo consequat.
    p.
      Duis aute irure dolor in reprehenderit
      in voluptate velit esse cillum dolore eu
      fugiat nulla pariatur.
    a(href="#" Next

returns a error message referring to line 4, while the error is really on line 13:

    Jade:4
        2|   Lorem ipsum dolor sit amet, consectetur  
        3|   adipisicing elit, sed do eiusmod tempor 
      > 4|   incididunt ut labore et dolore magna aliqua. 
        5| p.
        6|   Ut enim ad minim veniam, quis nostrud 
        7|   exercitation ullamco laboris nisi ut aliquip 
    The end of the string was reached with no closing bracket found.

The proposed edit helps to fix this - the line number points at the right lexeme (although it is still not possible to identify the exact line number if an error occurs within a single pipeless text block).