### PR TITLE
travis: Use after_success for coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ node_js:
 # Use faster Docker architecture on Travis.
 sudo: false
 
-script: "npm test && npm run coveralls"
+script:        npm test
+after_success: npm run coveralls
 
 notifications:
   webhooks:


### PR DESCRIPTION
This way the Travis build outcome is not affected by Coveralls server downtime, which unfortunately is an issue.