### PR TITLE
removed '=' from title tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Jade is a clean, whitespace sensitive syntax for writing html.  Here is a simple
 doctype html
 html(lang="en")
   head
-    title= pageTitle
+    title pageTitle
     script(type='text/javascript').
       if (foo) bar(1 + 5)
   body


### PR DESCRIPTION
The "=" sign after title causes an error: unexpected identifier at Function (native) at assertExpression. I removed the "=" and the error was gone. I'm adding screenshots to show my experience.

![screen shot 2015-06-01 at 12 46 40 pm](https://cloud.githubusercontent.com/assets/8284943/7921821/f694bf8c-085c-11e5-88e0-61f5c56a51cb.png)
![screen shot 2015-06-01 at 12 46 54 pm](https://cloud.githubusercontent.com/assets/8284943/7921825/fa0e696a-085c-11e5-9ef3-4897116c98c5.png)
![screen shot 2015-06-01 at 12 46 59 pm](https://cloud.githubusercontent.com/assets/8284943/7921827/fc556494-085c-11e5-9afe-7caa1d517021.png)
![screen shot 2015-06-01 at 12 47 07 pm](https://cloud.githubusercontent.com/assets/8284943/7921828/00b8d4bc-085d-11e5-9567-0cc03c2b32b6.png)
