### PR TITLE
improve mixin performance by fixing https://code.google.com/p/v8/issues/detail?id=4165

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -43,6 +43,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.parentIndents = 0;
   this.terse = false;
   this.mixins = {};
+  this.mixinsCount = 0;
   this.dynamicMixins = false;
   if (options.doctype) this.setDoctype(options.doctype);
 };
@@ -404,7 +405,8 @@ Compiler.prototype = {
       if (args.length && /^\.\.\./.test(args[args.length - 1].trim())) {
         rest = args.pop().trim().replace(/^\.\.\./, '');
       }
-      this.buf.push(name + ' = function(' + args.join(',') + '){');
+      this.buf.push('var jade_mixin_' + this.mixinsCount + ';');
+      this.buf.push(name + ' = jade_mixin_' + this.mixinsCount + ' = function(' + args.join(',') + '){');
       this.buf.push('var block = (this && this.block), attributes = (this && this.attributes) || {};');
       if (rest) {
         this.buf.push('var ' + rest + ' = [];');
@@ -418,6 +420,7 @@ Compiler.prototype = {
       this.buf.push('};');
       var mixin_end = this.buf.length;
       this.mixins[key].instances.push({start: mixin_start, end: mixin_end});
+      this.mixinsCount++;
     }
   },
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -43,7 +43,6 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.parentIndents = 0;
   this.terse = false;
   this.mixins = {};
-  this.mixinsCount = 0;
   this.dynamicMixins = false;
   if (options.doctype) this.setDoctype(options.doctype);
 };
@@ -405,8 +404,9 @@ Compiler.prototype = {
       if (args.length && /^\.\.\./.test(args[args.length - 1].trim())) {
         rest = args.pop().trim().replace(/^\.\.\./, '');
       }
-      this.buf.push('var jade_mixin_' + this.mixinsCount + ';');
-      this.buf.push(name + ' = jade_mixin_' + this.mixinsCount + ' = function(' + args.join(',') + '){');
+      // we need use jade_interp here for v8: https://code.google.com/p/v8/issues/detail?id=4165
+      // once fixed, use this: this.buf.push(name + ' = function(' + args.join(',') + '){');
+      this.buf.push(name + ' = jade_interp = function(' + args.join(',') + '){');
       this.buf.push('var block = (this && this.block), attributes = (this && this.attributes) || {};');
       if (rest) {
         this.buf.push('var ' + rest + ' = [];');
@@ -420,7 +420,6 @@ Compiler.prototype = {
       this.buf.push('};');
       var mixin_end = this.buf.length;
       this.mixins[key].instances.push({start: mixin_start, end: mixin_end});
-      this.mixinsCount++;
     }
   },
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -396,7 +396,7 @@ Parser.prototype = {
       node = new nodes.Code(text, false, false);
       return node;
   },
-  
+
   /**
    * comment
    */


### PR DESCRIPTION
(Part of https://github.com/jadejs/jade/issues/1975)
Found another weird bug in v8 - see jsperf http://jsperf.com/iterative-function-creation and v8 issue https://code.google.com/p/v8/issues/detail?id=4165

Anyhow, fixing it turns this
```
mixin-escape: 25284ms
mixin-no-escape: 17737ms
```
into
```
mixin-escape: 7463ms
mixin-no-escape: 2107ms
```

This PR assumes that all variables with names like ```jade_mixin_N``` are safe to use. If we don't want to make this assumption for the 1.x releases, we should bring it in 2.0. What do you think?