### PR TITLE
for loops are now generated inline rather than in an IIFE

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -590,46 +590,48 @@ Compiler.prototype = {
    */
 
   visitEach: function(each){
+    var $$obj = each.key + '__obj'
+      , $$l = each.key + '__l';
+
     this.buf.push(''
       + '// iterate ' + each.obj + '\n'
-      + ';(function(){\n'
-      + '  var $$obj = ' + each.obj + ';\n'
-      + '  if (\'number\' == typeof $$obj.length) {\n');
+      + 'var ' + $$obj + ' = ' + each.obj + ';\n'
+      + 'if (\'number\' == typeof ' + $$obj + '.length) {\n');
 
     if (each.alternative) {
-      this.buf.push('  if ($$obj.length) {');
+      this.buf.push('if (' + $$obj + '.length) {');
     }
 
     this.buf.push(''
-      + '    for (var ' + each.key + ' = 0, $$l = $$obj.length; ' + each.key + ' < $$l; ' + each.key + '++) {\n'
-      + '      var ' + each.val + ' = $$obj[' + each.key + '];\n');
+      + '  for (var ' + each.key + ' = 0, ' + $$l + ' = ' + $$obj + '.length; ' + each.key + ' < ' + $$l + '; ' + each.key + '++) {\n'
+      + '    var ' + each.val + ' = ' + $$obj + '[' + each.key + '];\n');
 
     this.visit(each.block);
 
-    this.buf.push('    }\n');
+    this.buf.push('  }\n');
 
     if (each.alternative) {
-      this.buf.push('  } else {');
+      this.buf.push('} else {');
+      this.visit(each.alternative);
+      this.buf.push('}');
+    }
+
+    this.buf.push(''
+      + '} else {\n'
+      + '  var ' + $$l + ' = 0;\n'
+      + '  for (var ' + each.key + ' in ' + $$obj + ') {\n'
+      + '    ' + $$l + '++;\n'
+      + '    var ' + each.val + ' = ' + $$obj + '[' + each.key + '];\n');
+
+    this.visit(each.block);
+
+    this.buf.push('  }\n');
+    if (each.alternative) {
+      this.buf.push('  if (' + $$l + ' === 0) {');
       this.visit(each.alternative);
       this.buf.push('  }');
     }
-
-    this.buf.push(''
-      + '  } else {\n'
-      + '    var $$l = 0;\n'
-      + '    for (var ' + each.key + ' in $$obj) {\n'
-      + '      $$l++;'
-      + '      var ' + each.val + ' = $$obj[' + each.key + '];\n');
-
-    this.visit(each.block);
-
-    this.buf.push('    }\n');
-    if (each.alternative) {
-      this.buf.push('    if ($$l === 0) {');
-      this.visit(each.alternative);
-      this.buf.push('    }');
-    }
-    this.buf.push('  }\n}).call(this);\n');
+    this.buf.push('}\n');
   },
 
   /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -44,6 +44,7 @@ var Compiler = module.exports = function Compiler(node, options) {
   this.terse = false;
   this.mixins = {};
   this.dynamicMixins = false;
+  this.eachCount = 0;
   if (options.doctype) this.setDoctype(options.doctype);
 };
 
@@ -590,21 +591,23 @@ Compiler.prototype = {
    */
 
   visitEach: function(each){
-    var $$obj = each.key + '__obj'
-      , $$l = each.key + '__l';
+    var indexVarName = each.key || 'jade_index' + this.eachCount
+      , objVarName = 'jade_obj' + this.eachCount
+      , lengthVarName = 'jade_length' + this.eachCount;
+    this.eachCount++;
 
     this.buf.push(''
       + '// iterate ' + each.obj + '\n'
-      + 'var ' + $$obj + ' = ' + each.obj + ';\n'
-      + 'if (\'number\' == typeof ' + $$obj + '.length) {\n');
+      + 'var ' + objVarName + ' = ' + each.obj + ';\n'
+      + 'if (\'number\' == typeof ' + objVarName + '.length) {\n');
 
     if (each.alternative) {
-      this.buf.push('if (' + $$obj + '.length) {');
+      this.buf.push('if (' + objVarName + '.length) {');
     }
 
     this.buf.push(''
-      + '  for (var ' + each.key + ' = 0, ' + $$l + ' = ' + $$obj + '.length; ' + each.key + ' < ' + $$l + '; ' + each.key + '++) {\n'
-      + '    var ' + each.val + ' = ' + $$obj + '[' + each.key + '];\n');
+      + '  for (var ' + indexVarName + ' = 0, ' + lengthVarName + ' = ' + objVarName + '.length; ' + indexVarName + ' < ' + lengthVarName + '; ' + indexVarName + '++) {\n'
+      + '    var ' + each.val + ' = ' + objVarName + '[' + indexVarName + '];\n');
 
     this.visit(each.block);
 
@@ -618,16 +621,16 @@ Compiler.prototype = {
 
     this.buf.push(''
       + '} else {\n'
-      + '  var ' + $$l + ' = 0;\n'
-      + '  for (var ' + each.key + ' in ' + $$obj + ') {\n'
-      + '    ' + $$l + '++;\n'
-      + '    var ' + each.val + ' = ' + $$obj + '[' + each.key + '];\n');
+      + '  var ' + lengthVarName + ' = 0;\n'
+      + '  for (var ' + indexVarName + ' in ' + objVarName + ') {\n'
+      + '    ' + lengthVarName + '++;\n'
+      + '    var ' + each.val + ' = ' + objVarName + '[' + indexVarName + '];\n');
 
     this.visit(each.block);
 
     this.buf.push('  }\n');
     if (each.alternative) {
-      this.buf.push('  if (' + $$l + ' === 0) {');
+      this.buf.push('  if (' + lengthVarName + ' === 0) {');
       this.visit(each.alternative);
       this.buf.push('  }');
     }

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -16,6 +16,7 @@ var Lexer = module.exports = function Lexer(str, filename) {
   this.input = str.replace(/\r\n|\r/g, '\n');
   this.filename = filename;
   this.deferredTokens = [];
+  this.eachCount = 0;
   this.lastIndents = 0;
   this.lineno = 1;
   this.stash = [];
@@ -561,7 +562,8 @@ Lexer.prototype = {
     if (captures = /^(?:- *)?(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * in *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('each', captures[1]);
-      tok.key = captures[2] || '$index';
+      tok.key = captures[2] || '$$i' + this.eachCount;
+      this.eachCount++;
       assertExpression(captures[3])
       tok.code = captures[3];
       return tok;

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -16,7 +16,6 @@ var Lexer = module.exports = function Lexer(str, filename) {
   this.input = str.replace(/\r\n|\r/g, '\n');
   this.filename = filename;
   this.deferredTokens = [];
-  this.eachCount = 0;
   this.lastIndents = 0;
   this.lineno = 1;
   this.stash = [];
@@ -562,8 +561,7 @@ Lexer.prototype = {
     if (captures = /^(?:- *)?(?:each|for) +([a-zA-Z_$][\w$]*)(?: *, *([a-zA-Z_$][\w$]*))? * in *([^\n]+)/.exec(this.input)) {
       this.consume(captures[0].length);
       var tok = this.tok('each', captures[1]);
-      tok.key = captures[2] || '$$i' + this.eachCount;
-      this.eachCount++;
+      tok.key = captures[2];
       assertExpression(captures[3])
       tok.code = captures[3];
       return tok;


### PR DESCRIPTION
This again improves performance a little bit (part of https://github.com/jadejs/jade/issues/1975).

The first change is to rename ```$index``` to ```$$iN```, where N is the Nth for loop. The PR assumes this is safe. It also assumes it is safe to use variables that look like ```KEY__obj``` and ```KEY__l```, where KEY is either ```$$iN``` or the KEY provided by the user.