### PR TITLE
Register .jade as a require-able file extension

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,0 +1,12 @@
+var jade = require('jade');
+
+function compileTemplate(module, filename) {
+  var template = jade.compileFileClient(filename);
+  var body = "var jade = require('jade/runtime');\n\n" +
+             "module.exports = " + template + ";";
+  module._compile(body, filename);
+}
+
+if (require.extensions) {
+  require.extensions['.jade'] = compileTemplate
+};


### PR DESCRIPTION
![](http://cdn.meme.am/instances2/500x/167269.jpg)

This was driven by a desire to test client-side code compiled via [browserify](http://browserify.org/) using [mocha.js](http://mochajs.org/), which runs in `node` instead of the browser.  With `browserify`, it's easy to just require your template functions directly:
```js
var template = require('templates/kitten');  // a .jade template
```
and let a transform like [jadeify](https://www.npmjs.com/package/jadeify) do the heavy lifting for you.  Regular `node` complains, however, and when you attempt to require a template directly, it will (correctly) whine about not having a compiler for that file extension.

This PR adds a way to register `.jade` as a valid extension for require-able template functions, and was heavily inspired by [coffee-script/register](https://github.com/jashkenas/coffeescript/blob/master/src/register.coffee#L6-L15) and the [meat of jadeify](https://github.com/domenic/jadeify/blob/master/lib/jadeify.js#L35-L36).  Now if you add one line to the example above, `node` doesn't mind anymore:
```js
require('jade/register');
var template = require('templates/kitten');  // returns a real template function
```
You can even register it as a watchable extension for `mocha.js` in your `mocha.opts`, as well:
```
--compilers coffee:coffee-script/register,jade:jade/register
```