### PR TITLE
RFC: Expressions in Statements

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -479,8 +479,16 @@ Parser.prototype = {
 
   parseExtends: function(){
     var fs = require('fs');
+    var path = this.expect('extends').val.trim();
 
-    var path = this.resolvePath(this.expect('extends').val.trim(), 'extends');
+    if ('{' === path.substr(0, 1) && '}' === path.substr(-1)) {
+      path = path.substring(1);
+      path = path.substring(0, path.length - 1);
+      path = eval(path);
+    } else {
+      path = this.resolvePath(path, 'extends');
+    }
+
     if ('.jade' != path.substr(-5)) path += '.jade';
 
     this.dependencies.push(path);


### PR DESCRIPTION
To support a project that is currently locked at 1.7.0, I needed the ability to dynamically evaluate the parameter passed to the `extends` statement.  I quickly hacked in the attached change, which is obviously suboptimal, and am opening this pull request to seek guidance on how this might otherwise be achieved (especially in newer versions of Jade).

What this looks like in practice:
```jade
extends {process.env.PWD + '/views/layouts/default'}

block content
  #page-content !{content}
```

This pull request was implemented on top of the `1.7.0` tag, so it obviously is not mergeable against `master`.  Seeking comments on how this might be addressed otherwise.