### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "less-file": "0.0.9",
     "linify": "*",
     "lsr": "^1.0.0",
-    "marked": "~0.3.3",
+    "marked": "^0.3.5",
     "mocha": "*",
     "opener": "^1.3.0",
     "pull-request": "^3.0.0",
@@ -67,7 +67,7 @@
     "stop": "^3.0.0-rc1",
     "stylus": "*",
     "twbs": "0.0.6",
-    "uglify-js": "^2.4.23"
+    "uglify-js": "^2.4.24"
   },
   "scripts": {
     "test": "mocha -R spec --bail",


### PR DESCRIPTION
`marked` and `uglify-js` have several reported security issues in versions used by jade:
- https://nodesecurity.io/advisories/module/marked
- https://nodesecurity.io/advisories/module/uglify-js