### PR TITLE
Docu typos

### DIFF
--- a/docs/views/reference/comments.jade
+++ b/docs/views/reference/comments.jade
@@ -70,15 +70,15 @@ block documentation
           <!--[if IE 8]>
           <html lang="en" class="lt-ie9">
           <![endif]-->
-          <!--[if gt IE 8]><!-->
+          <!--[if gt IE 8]>
           <html lang="en">
-          <!--<![endif]-->
+          <![endif]-->
     .col-lg-6
       +html
         :htmlsrc
           <!--[if IE 8]>
           <html lang="en" class="lt-ie9">
           <![endif]-->
-          <!--[if gt IE 8]><!-->
+          <!--[if gt IE 8]>
           <html lang="en">
-          <!--<![endif]-->
+          <![endif]-->

--- a/docs/views/reference/inheritance.jade
+++ b/docs/views/reference/inheritance.jade
@@ -38,7 +38,7 @@ block documentation
       block content
         h1= title
         each pet in pets
-          include pet
+          p= pet
 
   p.
     It's also possible to override a block to provide additional blocks, as shown in the following example where #[code content] now exposes a #[code sidebar] and #[code primary] block for overriding, or the child template could override #[code content] all together.


### PR DESCRIPTION
While doing the exercises from http://jade-lang.com/reference/, I stubled upon what I think are some small typos.


Also not sure about this one but, http://jade-lang.com/reference/tags/ mentions at the end "Self Closing Tags". But doing `foo/`generates a `<foo>` and not a `<foo />` as advertised. Not sure if this is a bug.