### PR TITLE
Fix stylus import test

### DIFF
--- a/test/cases/some.styl
+++ b/test/cases/some.styl
@@ -1,1 +1,1 @@
-@import "test/cases/some-included"
+@import "some-included"


### PR DESCRIPTION
Stylus `@import` defaults to the directory of the source file.