### PR TITLE
Add missing `-H, --hierarchy` flag to command-line template.

### DIFF
--- a/docs/views/command-line.jade
+++ b/docs/views/command-line.jade
@@ -30,6 +30,7 @@ block content
         -D, --no-debug         compile without debugging (smaller functions)
         -w, --watch            watch files for changes and automatically re-render
         -E, --extension <ext>  specify the output file extension
+        -H, --hierarchy        keep directory hierarchy when a directory is specified
         --name-after-file      name the template after the last section of the file path
                                (requires --client and overriden by --name)
         --doctype <str>        specify the doctype on the command line (useful if it


### PR DESCRIPTION
The `-H` flag appears for

```
$ jade --help
```

but not at http://jade-lang.com/command-line/