### PR TITLE
Update uglify.js to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "stop": "^3.0.0-rc1",
     "stylus": "*",
     "twbs": "0.0.6",
-    "uglify-js": "^2.4.24"
+    "uglify-js": "^2.6.1"
   },
   "scripts": {
     "test": "mocha -R spec",


### PR DESCRIPTION
To include a fix (mishoo/UglifyJS2@63d35f8) for https://nodesecurity.io/advisories/48

Also filed jstransformers/jstransformer-uglify-js#6 to update that dependency.